### PR TITLE
Remove redundant definition

### DIFF
--- a/src/kernels/fbm.jl
+++ b/src/kernels/fbm.jl
@@ -62,10 +62,6 @@ function kernelmatrix!(
     return K
 end
 
-function _kernel(κ::FBMKernel, x::Real, y::Real)
-    _kernel(κ, [x], [y])
-end
-
 ## Apply kernel on two vectors ##
 function _kernel(
         κ::FBMKernel,


### PR DESCRIPTION
As @willtebbutt correctly noted in https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/pull/48#issuecomment-604919950, this definition is not needed. It is covered by the more general definition [here](https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/blob/1081e46399a3a3682b6f121fd7317a4d79a55f5b/src/matrix/kernelmatrix.jl#L45).