### PR TITLE
Add alias for SelectTransform as Mask

### DIFF
--- a/src/transform/selecttransform.jl
+++ b/src/transform/selecttransform.jl
@@ -38,3 +38,6 @@ function apply(t::SelectTransform, x::AbstractVector{<:Real}; obsdim::Int = defa
 end
 
 _transform(t::SelectTransform,X::AbstractMatrix{<:Real},obsdim::Int=defaultobs) = obsdim == 2 ? view(X,t.select,:) : view(X,:,t.select)
+
+## Aliases ##
+const Mask = SelectTransform

--- a/test/test_transform.jl
+++ b/test/test_transform.jl
@@ -60,11 +60,16 @@ f(x) = sin.(x)
     ## Test SelectTransform
     @testset "SelectTransform" begin
         ts = SelectTransform(sdims)
+        mask = Mask(sdims)
+        @test mask == ts
+        @test all(KernelFunctions.apply(ts,X,obsdim=2).==KernelFunctions.apply(mask,X,obsdim=2))
         @test all(KernelFunctions.apply(ts,X,obsdim=2).==X[sdims,:])
         @test all(KernelFunctions.apply(ts,x).==x[sdims])
         sdims2 = [2,3,5]
         KernelFunctions.set!(ts,sdims2)
+        KernelFunctions.set!(mask,sdims2)
         @test all(ts.select.==sdims2)
+        @test all(ts.select.==mask.select)
     end
     ## Test ChainTransform
     @testset "ChainTransform" begin


### PR DESCRIPTION
Fixes #47 

I have added alias for `SelectTransform` as `Mask` and also added tests for the same.

Please review.