### PR TITLE
Add general TensorProduct kernel

### DIFF
--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -19,6 +19,7 @@ export MahalanobisKernel, GaborKernel, PiecewisePolynomialKernel
 export PeriodicKernel
 export KernelSum, KernelProduct
 export TransformedKernel, ScaledKernel
+export TensorProduct
 
 export Transform, SelectTransform, ChainTransform, ScaleTransform, LowRankTransform, IdentityTransform, FunctionTransform
 
@@ -56,6 +57,7 @@ include("kernels/scaledkernel.jl")
 include("matrix/kernelmatrix.jl")
 include("kernels/kernelsum.jl")
 include("kernels/kernelproduct.jl")
+include("kernels/tensorproduct.jl")
 include("approximations/nystrom.jl")
 include("generic.jl")
 

--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -40,14 +40,16 @@ function kernelmatrix!(
 
     featuredim = feature_dim(obsdim)
     if !check_dims(K, X, X, featuredim, obsdim)
-        throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
+        throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not " *
+                                "consistent with X $(size(X))"))
     end
 
     size(X, featuredim) == length(kernel) ||
         error("number of kernels and groups of features are not consistent")
 
-    kernelmatrix!(K, kernel.kernels[1], selectdim(X, featuredim, 1))
-    for (k, Xi) in Iterators.drop(zip(kernel.kernels, eachslice(X; dims = featuredim)), 1)
+    kernels_and_input = zip(kernel.kernels, eachslice(X; dims = featuredim))
+    kernelmatrix!(K, first(kernels_and_input)...)
+    for (k, Xi) in Iterators.drop(kernels_and_input, 1)
         K .*= kernelmatrix(k, Xi)
     end
 
@@ -65,14 +67,15 @@ function kernelmatrix!(
 
     featuredim = feature_dim(obsdim)
     if !check_dims(K, X, Y, featuredim, obsdim)
-        throw(DimensionMismatch("Dimensions $(size(K)) of the target array K are not consistent with X ($(size(X))) and Y ($(size(Y)))"))
+        throw(DimensionMismatch("Dimensions $(size(K)) of the target array K are not " *
+                                "consistent with X ($(size(X))) and Y ($(size(Y)))"))
     end
 
     size(X, featuredim) == length(kernel) ||
         error("number of kernels and groups of features are not consistent")
 
     kernels_and_input = zip(
-        zip(kernel.kernels,
+        kernel.kernels,
         eachslice(X; dims = featuredim),
         eachslice(Y; dims = featuredim),
     )
@@ -95,7 +98,8 @@ function kernelmatrix(
 
     featuredim = feature_dim(obsdim)
     if !check_dims(X, X, featuredim, obsdim)
-        throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
+        throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not " *
+                                "consistent with X $(size(X))"))
     end
 
     size(X, featuredim) == length(kernel) ||
@@ -113,11 +117,12 @@ function kernelmatrix(
     Y::AbstractMatrix;
     obsdim::Int = defaultobs
 )
-    @assert obsdim ∈ (1, 2) || error("obsdim should be 1 or 2 (see docs of kernelmatrix))")
+    obsdim ∈ (1, 2) || error("obsdim should be 1 or 2 (see docs of kernelmatrix))")
 
     featuredim = feature_dim(obsdim)
     if !check_dims(X, Y, featuredim, obsdim)
-        throw(DimensionMismatch("Dimensions $(size(K)) of the target array K are not consistent with X ($(size(X))) and Y ($(size(Y)))"))
+        throw(DimensionMismatch("Dimensions $(size(K)) of the target array K are not " *
+                                "consistent with X ($(size(X))) and Y ($(size(Y)))"))
     end
 
     size(X, featuredim) == length(kernel) ||
@@ -141,15 +146,17 @@ function kerneldiagmatrix!(
 )
     obsdim ∈ (1, 2) || error("obsdim should be 1 or 2 (see docs of kernelmatrix))")
     if length(K) != size(X, obsdim)
-        throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
+        throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not " *
+                                "consistent with X $(size(X))"))
     end
 
     featuredim = feature_dim(obsdim)
     size(X, featuredim) == length(kernel) ||
         error("number of kernels and groups of features are not consistent")
 
-    kerneldiagmatrix!(K, kernel.kernels[1], selectdim(X, featuredim, 1))
-    for (k, Xi) in Iterators.drop(zip(kernel.kernels, eachslice(X; dims = featuredim)), 1)
+    kernels_and_input = zip(kernel.kernels, eachslice(X; dims = featuredim))
+    kerneldiagmatrix!(K, first(kernels_and_input)...)
+    for (k, Xi) in Iterators.drop(kernels_and_input, 1)
         K .*= kerneldiagmatrix(k, Xi)
     end
 

--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -1,0 +1,33 @@
+"""
+    TensorProduct(kernels...)
+
+Create a tensor product of kernels.
+"""
+struct TensorProduct{K} <: Kernel
+    kernels::K
+end
+
+function TensorProduct(kernel::Kernel, kernels::Kernel...)
+    return TensorProduct((kernel, kernels...))
+end
+
+Base.length(kernel::TensorProduct) = length(kernel.kernels)
+
+(kernel::TensorProduct)(x, y) = kappa(kernel, x, y)
+function kappa(kernel::TensorProduct, x, y)
+    return prod(kappa(k, xi, yi) for (k, xi, yi) in zip(kernel.kernels, x, y))
+end
+
+Base.show(io::IO, kernel::TensorProduct) = printshifted(io, kernel, 0)
+
+function printshifted(io::IO, kernel::TensorProduct, shift::Int)
+    print(io, "Tensor product of ", length(kernel), " kernels:")
+    for k in kernel.kernels
+        print(io, "\n")
+        for _ in 1:(shift + 1)
+            print(io, "\t")
+        end
+        print(io, "- ")
+        printshifted(io, k, shift + 2)
+    end
+end

--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -18,6 +18,148 @@ function kappa(kernel::TensorProduct, x, y)
     return prod(kappa(k, xi, yi) for (k, xi, yi) in zip(kernel.kernels, x, y))
 end
 
+# TODO: General implementation of `kernelmatrix` and `kerneldiagmatrix`
+# Default implementation assumes 1D observations
+
+function kernelmatrix!(
+    K::AbstractMatrix,
+    kernel::TensorProduct,
+    X::AbstractMatrix;
+    obsdim::Int = defaultobs
+)
+    obsdim ∈ (1, 2) || "obsdim should be 1 or 2 (see docs of kernelmatrix))"
+
+    featuredim = feature_dim(obsdim)
+    if !check_dims(K, X, X, featuredim, obsdim)
+        throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
+    end
+
+    size(X, featuredim) == length(kernel) ||
+        error("number of kernels and groups of features are not consistent")
+
+    kernelmatrix!(K, kernel.kernels[1], selectdim(X, featuredim, 1))
+    for (k, Xi) in Iterators.drop(zip(kernel.kernels, eachslice(X; dims = featuredim)), 1)
+        K .*= kernelmatrix(k, Xi)
+    end
+
+    return K
+end
+
+function kernelmatrix!(
+    K::AbstractMatrix,
+    kernel::TensorProduct,
+    X::AbstractMatrix,
+    Y::AbstractMatrix;
+    obsdim::Int = defaultobs
+)
+    obsdim ∈ (1, 2) || error("obsdim should be 1 or 2 (see docs of kernelmatrix))")
+
+    featuredim = feature_dim(obsdim)
+    if !check_dims(K, X, Y, featuredim, obsdim)
+        throw(DimensionMismatch("Dimensions $(size(K)) of the target array K are not consistent with X ($(size(X))) and Y ($(size(Y)))"))
+    end
+
+    size(X, featuredim) == length(kernel) ||
+        error("number of kernels and groups of features are not consistent")
+
+    kernelmatrix!(K, kernel.kernels[1], selectdim(X, featuredim, 1),
+                  selectdim(Y, featuredim, 1))
+    for (k, Xi, Yi) in Iterators.drop(zip(kernel.kernels,
+                                          eachslice(X; dims = featuredim),
+                                          eachslice(Y; dims = featuredim)), 1)
+        K .*= kernelmatrix(k, Xi, Yi)
+    end
+
+    return K
+end
+
+# mapreduce with multiple iterators requires Julia 1.2 or later.
+
+function kernelmatrix(
+    kernel::TensorProduct,
+    X::AbstractMatrix;
+    obsdim::Int = defaultobs
+)
+    obsdim ∈ (1, 2) || error("obsdim should be 1 or 2 (see docs of kernelmatrix))")
+
+    featuredim = feature_dim(obsdim)
+    if !check_dims(X, X, featuredim, obsdim)
+        throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
+    end
+
+    size(X, featuredim) == length(kernel) ||
+        error("number of kernels and groups of features are not consistent")
+
+    return mapreduce((x, y) -> x .* y,
+                     zip(kernel.kernels, eachslice(X; dims = featuredim))) do (k, Xi)
+        kernelmatrix(k, Xi)
+    end
+end
+
+function kernelmatrix(
+    kernel::TensorProduct,
+    X::AbstractMatrix,
+    Y::AbstractMatrix;
+    obsdim::Int = defaultobs
+)
+    @assert obsdim ∈ (1, 2) || error("obsdim should be 1 or 2 (see docs of kernelmatrix))")
+
+    featuredim = feature_dim(obsdim)
+    if !check_dims(X, Y, featuredim, obsdim)
+        throw(DimensionMismatch("Dimensions $(size(K)) of the target array K are not consistent with X ($(size(X))) and Y ($(size(Y)))"))
+    end
+
+    size(X, featuredim) == length(kernel) ||
+        error("number of kernels and groups of features are not consistent")
+
+    return mapreduce((x, y) -> x .* y,
+                     zip(kernel.kernels,
+                         eachslice(X; dims = featuredim),
+                         eachslice(Y; dims = featuredim))) do (k, Xi, Yi)
+        kernelmatrix(k, Xi, Yi)
+    end
+end
+
+function kerneldiagmatrix!(
+    K::AbstractVector,
+    kernel::TensorProduct,
+    X::AbstractMatrix;
+    obsdim::Int = defaultobs
+)
+    obsdim ∈ (1, 2) || error("obsdim should be 1 or 2 (see docs of kernelmatrix))")
+    if length(K) != size(X, obsdim)
+        throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
+    end
+
+    featuredim = feature_dim(obsdim)
+    size(X, featuredim) == length(kernel) ||
+        error("number of kernels and groups of features are not consistent")
+
+    kerneldiagmatrix!(K, kernel.kernels[1], selectdim(X, featuredim, 1))
+    for (k, Xi) in Iterators.drop(zip(kernel.kernels, eachslice(X; dims = featuredim)), 1)
+        K .*= kerneldiagmatrix(k, Xi)
+    end
+
+    return K
+end
+
+function kerneldiagmatrix(
+    kernel::TensorProduct,
+    X::AbstractMatrix;
+    obsdim::Int = defaultobs
+)
+    obsdim ∈ (1,2) || error("obsdim should be 1 or 2 (see docs of kernelmatrix))")
+
+    featuredim = feature_dim(obsdim)
+    size(X, featuredim) == length(kernel) ||
+        error("number of kernels and groups of features are not consistent")
+
+    return mapreduce((x, y) -> x .* y,
+                     zip(kernel.kernels, eachslice(X; dims = featuredim))) do (k, Xi)
+         kerneldiagmatrix(k, Xi)
+    end
+end
+
 Base.show(io::IO, kernel::TensorProduct) = printshifted(io, kernel, 0)
 
 function printshifted(io::IO, kernel::TensorProduct, shift::Int)

--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -1,7 +1,16 @@
 """
     TensorProduct(kernels...)
 
-Create a tensor product of kernels.
+Create a tensor product kernel from kernels ``k_1, \\ldots, k_n``, i.e.,
+a kernel ``k`` that is given by
+```math
+k(x, y) = \\prod_{i=1}^n k_i(x_i, y_i).
+```
+
+The `kernels` can be specified as individual arguments, a tuple, or an iterable data
+structure such as an array. Using a tuple or individual arguments guarantees that
+`TensorProduct` is concretely typed but might lead to large compilation times if the
+number of kernels is large.
 """
 struct TensorProduct{K} <: Kernel
     kernels::K

--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -47,9 +47,9 @@ function kernelmatrix!(
     size(X, featuredim) == length(kernel) ||
         error("number of kernels and groups of features are not consistent")
 
-    kernels_and_input = zip(kernel.kernels, eachslice(X; dims = featuredim))
-    kernelmatrix!(K, first(kernels_and_input)...)
-    for (k, Xi) in Iterators.drop(kernels_and_input, 1)
+    kernels_and_inputs = zip(kernel.kernels, eachslice(X; dims = featuredim))
+    kernelmatrix!(K, first(kernels_and_inputs)...)
+    for (k, Xi) in Iterators.drop(kernels_and_inputs, 1)
         K .*= kernelmatrix(k, Xi)
     end
 
@@ -74,7 +74,7 @@ function kernelmatrix!(
     size(X, featuredim) == length(kernel) ||
         error("number of kernels and groups of features are not consistent")
 
-    kernels_and_input = zip(
+    kernels_and_inputs = zip(
         kernel.kernels,
         eachslice(X; dims = featuredim),
         eachslice(Y; dims = featuredim),
@@ -154,9 +154,9 @@ function kerneldiagmatrix!(
     size(X, featuredim) == length(kernel) ||
         error("number of kernels and groups of features are not consistent")
 
-    kernels_and_input = zip(kernel.kernels, eachslice(X; dims = featuredim))
-    kerneldiagmatrix!(K, first(kernels_and_input)...)
-    for (k, Xi) in Iterators.drop(kernels_and_input, 1)
+    kernels_and_inputs = zip(kernel.kernels, eachslice(X; dims = featuredim))
+    kerneldiagmatrix!(K, first(kernels_and_inputs)...)
+    for (k, Xi) in Iterators.drop(kernels_and_inputs, 1)
         K .*= kerneldiagmatrix(k, Xi)
     end
 

--- a/src/matrix/kernelmatrix.jl
+++ b/src/matrix/kernelmatrix.jl
@@ -10,7 +10,7 @@ function kernelmatrix!(
     K::AbstractMatrix,
     kernel::Kernel,
     X::AbstractVector;
-    obsdim::Int = defaultobs
+    obsdim::Int = defaultobs,
 )
     return kernelmatrix!(K, kernel, reshape(X, 1, :); obsdim = 2)
 end
@@ -36,7 +36,7 @@ function kernelmatrix!(
     kernel::Kernel,
     X::AbstractVector,
     Y::AbstractVector;
-    obsdim::Int = defaultobs
+    obsdim::Int = defaultobs,
 )
     return kernelmatrix!(K, kernel, reshape(X, 1, :), reshape(Y, 1, :); obsdim = 2)
 end
@@ -110,7 +110,7 @@ function kernelmatrix(
     kernel::Kernel,
     X::AbstractVector{<:Real},
     Y::AbstractVector{<:Real};
-    obsdim::Int = defaultobs
+    obsdim::Int = defaultobs,
 )
     return kernelmatrix(kernel, reshape(X, 1, :), reshape(Y, 1, :); obsdim = 2)
 end
@@ -143,7 +143,7 @@ Calculate the diagonal matrix of `X` with respect to kernel `κ`
 function kerneldiagmatrix(
     kernel::Kernel,
     X::AbstractVector;
-    obsdim::Int = defaultobs
+    obsdim::Int = defaultobs,
 )
     return kerneldiagmatrix(kernel, reshape(X, 1, :); obsdim = 2)
 end
@@ -170,7 +170,7 @@ function kerneldiagmatrix!(
     K::AbstractVector,
     kernel::Kernel,
     X::AbstractVector;
-    obsdim::Int = defaultobs
+    obsdim::Int = defaultobs,
 )
     return kerneldiagmatrix!(K, kernel, reshape(X, 1, :); obsdim = 2)
 end

--- a/src/matrix/kernelmatrix.jl
+++ b/src/matrix/kernelmatrix.jl
@@ -1,11 +1,19 @@
 """
-    kernelmatrix!(K::Matrix, κ::Kernel, X::Matrix; obsdim::Integer = 2)
-    kernelmatrix!(K::Matrix, κ::Kernel, X::Matrix, Y::Matrix; obsdim::Integer = 2)
+    kernelmatrix!(K::AbstractMatrix, κ::Kernel, X; obsdim::Integer = 2)
+    kernelmatrix!(K::AbstractMatrix, κ::Kernel, X, Y; obsdim::Integer = 2)
 
 In-place version of [`kernelmatrix`](@ref) where pre-allocated matrix `K` will be overwritten with the kernel matrix.
 """
 kernelmatrix!
 
+function kernelmatrix!(
+    K::AbstractMatrix,
+    kernel::Kernel,
+    X::AbstractVector;
+    obsdim::Int = defaultobs
+)
+    return kernelmatrix!(K, kernel, reshape(X, 1, :); obsdim = 2)
+end
 
 function kernelmatrix!(
         K::AbstractMatrix,
@@ -22,6 +30,16 @@ end
 
 kernelmatrix!(K::AbstractMatrix, κ::TransformedKernel, X::AbstractMatrix; obsdim::Int = defaultobs) =
         kernelmatrix!(K, kernel(κ), apply(κ.transform, X, obsdim = obsdim), obsdim = obsdim)
+
+function kernelmatrix!(
+    K::AbstractMatrix,
+    kernel::Kernel,
+    X::AbstractVector,
+    Y::AbstractVector;
+    obsdim::Int = defaultobs
+)
+    return kernelmatrix!(K, kernel, reshape(X, 1, :), reshape(Y, 1, :); obsdim = 2)
+end
 
 function kernelmatrix!(
         K::AbstractMatrix,
@@ -60,8 +78,8 @@ _kernel(κ::TransformedKernel, x::AbstractVector, y::AbstractVector; obsdim::Int
         _kernel(kernel(κ), apply(κ.transform, x), apply(κ.transform, y), obsdim = obsdim)
 
 """
-    kernelmatrix(κ::Kernel, X::Matrix; obsdim::Int = 2)
-    kernelmatrix(κ::Kernel, X::Matrix, Y::Matrix; obsdim::Int = 2)
+    kernelmatrix(κ::Kernel, X; obsdim::Int = 2)
+    kernelmatrix(κ::Kernel, X, Y; obsdim::Int = 2)
 
 Calculate the kernel matrix of `X` (and `Y`) with respect to kernel `κ`.
 `obsdim = 1` means the matrix `X` (and `Y`) has size #samples x #dimension
@@ -89,6 +107,15 @@ kernelmatrix(κ::TransformedKernel, X::AbstractMatrix; obsdim::Int = defaultobs)
         kernelmatrix(kernel(κ), apply(κ.transform, X, obsdim = obsdim), obsdim = obsdim)
 
 function kernelmatrix(
+    kernel::Kernel,
+    X::AbstractVector{<:Real},
+    Y::AbstractVector{<:Real};
+    obsdim::Int = defaultobs
+)
+    return kernelmatrix(kernel, reshape(X, 1, :), reshape(Y, 1, :); obsdim = 2)
+end
+
+function kernelmatrix(
         κ::Kernel,
         X::AbstractMatrix,
         Y::AbstractMatrix;
@@ -107,12 +134,20 @@ kernelmatrix(κ::TransformedKernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim
         kernelmatrix(kernel(κ), apply(κ.transform, X, obsdim = obsdim), apply(κ.transform, Y, obsdim = obsdim), obsdim = obsdim)
 
 """
-    kerneldiagmatrix(κ::Kernel, X::Matrix; obsdim::Int = 2)
+    kerneldiagmatrix(κ::Kernel, X; obsdim::Int = 2)
 
 Calculate the diagonal matrix of `X` with respect to kernel `κ`
 `obsdim = 1` means the matrix `X` has size #samples x #dimension
 `obsdim = 2` means the matrix `X` has size #dimension x #samples
 """
+function kerneldiagmatrix(
+    kernel::Kernel,
+    X::AbstractVector;
+    obsdim::Int = defaultobs
+)
+    return kerneldiagmatrix(kernel, reshape(X, 1, :); obsdim = 2)
+end
+
 function kerneldiagmatrix(
         κ::Kernel,
         X::AbstractMatrix;
@@ -127,10 +162,19 @@ function kerneldiagmatrix(
 end
 
 """
-    kerneldiagmatrix!(K::AbstractVector,κ::Kernel, X::Matrix; obsdim::Int = 2)
+    kerneldiagmatrix!(K::AbstractVector, κ::Kernel, X; obsdim::Int = 2)
 
 In place version of [`kerneldiagmatrix`](@ref)
 """
+function kerneldiagmatrix!(
+    K::AbstractVector,
+    kernel::Kernel,
+    X::AbstractVector;
+    obsdim::Int = defaultobs
+)
+    return kerneldiagmatrix!(K, kernel, reshape(X, 1, :); obsdim = 2)
+end
+
 function kerneldiagmatrix!(
         K::AbstractVector,
         κ::Kernel,

--- a/test/kernels/tensorproduct.jl
+++ b/test/kernels/tensorproduct.jl
@@ -1,0 +1,23 @@
+@testset "tensorproduct" begin
+    rng = MersenneTwister(123456)
+    u1 = rand(rng, 10)
+    u2 = rand(rng, 10)
+    v1 = rand(rng, 5)
+    v2 = rand(rng, 5)
+
+    # kernels
+    k1 = SqExponentialKernel()
+    k2 = ExponentialKernel()
+    kernel1 = TensorProduct(k1, k2)
+    kernel2 = TensorProduct([k1, k2])
+
+    @test kernel1.kernels === (k1, k2) === TensorProduct((k1, k2)).kernels
+
+    for (x, y) in (((v1, u1), (v2, u2)), ([v1, u1], [v2, u2]))
+        val = k1(x[1], y[1]) * k2(x[2], y[2])
+
+        @test kernel1(x, y) == kernel2(x, y) == val
+        @test KernelFunctions.kappa(kernel1, x, y) ==
+            KernelFunctions.kappa(kernel2, x, y) == val
+    end
+end

--- a/test/kernels/tensorproduct.jl
+++ b/test/kernels/tensorproduct.jl
@@ -12,6 +12,7 @@
     kernel2 = TensorProduct([k1, k2])
 
     @test kernel1.kernels === (k1, k2) === TensorProduct((k1, k2)).kernels
+    @test length(kernel1) == length(kernel2) == 2
 
     @testset "kappa" begin
         for (x, y) in (((v1, u1), (v2, u2)), ([v1, u1], [v2, u2]))
@@ -24,8 +25,8 @@
     end
 
     @testset "kernelmatrix" begin
-        X = rand(2, 10)
-        Y = rand(2, 10)
+        X = rand(rng, 2, 10)
+        Y = rand(rng, 2, 10)
         trueX = kernelmatrix(k1, X[1, :]) .* kernelmatrix(k2, X[2, :])
         trueXY = kernelmatrix(k1, X[1, :], Y[1, :]) .* kernelmatrix(k2, X[2, :], Y[2, :])
         tmp = Matrix{Float64}(undef, 10, 10)
@@ -56,11 +57,72 @@
     end
 
     @testset "kerneldiagmatrix" begin
-        X = rand(2, 10)
+        X = rand(rng, 2, 10)
         trueval = ones(10)
         tmp = Vector{Float64}(undef, 10)
 
         for kernel in (kernel1, kernel2)
+            @test kerneldiagmatrix(kernel, X) == trueval
+            @test kerneldiagmatrix(kernel, X'; obsdim = 1) == trueval
+
+            fill!(tmp, 0)
+            kerneldiagmatrix!(tmp, kernel, X)
+            @test tmp == trueval
+
+            fill!(tmp, 0)
+            kerneldiagmatrix!(tmp, kernel, X'; obsdim = 1)
+            @test tmp == trueval
+        end
+    end
+
+    @testset "single kernel" begin
+        kernel = TensorProduct(k1)
+        @test length(kernel) == 1
+
+        @testset "kappa" begin
+            for (x, y) in (((v1,), (v2,)), ([v1], [v2]))
+                val = k1(x[1], y[1])
+
+                @test kernel(x, y) == val
+                @test KernelFunctions.kappa(kernel, x, y) == val
+            end
+        end
+
+        @testset "kernelmatrix" begin
+            X = rand(rng, 1, 10)
+            Y = rand(rng, 1, 10)
+            trueX = kernelmatrix(k1, X)
+            trueXY = kernelmatrix(k1, X, Y)
+            tmp = Matrix{Float64}(undef, 10, 10)
+
+            @test kernelmatrix(kernel, X) == trueX
+            @test kernelmatrix(kernel, X'; obsdim = 1) == trueX
+
+            @test kernelmatrix(kernel, X, Y) == trueXY
+            @test kernelmatrix(kernel, X', Y'; obsdim = 1) == trueXY
+
+            fill!(tmp, 0)
+            kernelmatrix!(tmp, kernel, X)
+            @test tmp == trueX
+
+            fill!(tmp, 0)
+            kernelmatrix!(tmp, kernel, X'; obsdim = 1)
+            @test tmp == trueX
+
+            fill!(tmp, 0)
+            kernelmatrix!(tmp, kernel, X, Y)
+            @test tmp == trueXY
+
+            fill!(tmp, 0)
+            kernelmatrix!(tmp, kernel, X', Y'; obsdim = 1)
+            @test tmp == trueXY
+        end
+
+        @testset "kerneldiagmatrix" begin
+            X = rand(rng, 1, 10)
+            trueval = ones(10)
+            tmp = Vector{Float64}(undef, 10)
+
             @test kerneldiagmatrix(kernel, X) == trueval
             @test kerneldiagmatrix(kernel, X'; obsdim = 1) == trueval
 

--- a/test/kernels/tensorproduct.jl
+++ b/test/kernels/tensorproduct.jl
@@ -13,11 +13,64 @@
 
     @test kernel1.kernels === (k1, k2) === TensorProduct((k1, k2)).kernels
 
-    for (x, y) in (((v1, u1), (v2, u2)), ([v1, u1], [v2, u2]))
-        val = k1(x[1], y[1]) * k2(x[2], y[2])
+    @testset "kappa" begin
+        for (x, y) in (((v1, u1), (v2, u2)), ([v1, u1], [v2, u2]))
+            val = k1(x[1], y[1]) * k2(x[2], y[2])
 
-        @test kernel1(x, y) == kernel2(x, y) == val
-        @test KernelFunctions.kappa(kernel1, x, y) ==
-            KernelFunctions.kappa(kernel2, x, y) == val
+            @test kernel1(x, y) == kernel2(x, y) == val
+            @test KernelFunctions.kappa(kernel1, x, y) ==
+                KernelFunctions.kappa(kernel2, x, y) == val
+        end
+    end
+
+    @testset "kernelmatrix" begin
+        X = rand(2, 10)
+        Y = rand(2, 10)
+        trueX = kernelmatrix(k1, X[1, :]) .* kernelmatrix(k2, X[2, :])
+        trueXY = kernelmatrix(k1, X[1, :], Y[1, :]) .* kernelmatrix(k2, X[2, :], Y[2, :])
+        tmp = Matrix{Float64}(undef, 10, 10)
+
+        for kernel in (kernel1, kernel2)
+            @test kernelmatrix(kernel, X) == trueX
+            @test kernelmatrix(kernel, X'; obsdim = 1) == trueX
+
+            @test kernelmatrix(kernel, X, Y) == trueXY
+            @test kernelmatrix(kernel, X', Y'; obsdim = 1) == trueXY
+
+            fill!(tmp, 0)
+            kernelmatrix!(tmp, kernel, X)
+            @test tmp == trueX
+
+            fill!(tmp, 0)
+            kernelmatrix!(tmp, kernel, X'; obsdim = 1)
+            @test tmp == trueX
+
+            fill!(tmp, 0)
+            kernelmatrix!(tmp, kernel, X, Y)
+            @test tmp == trueXY
+
+            fill!(tmp, 0)
+            kernelmatrix!(tmp, kernel, X', Y'; obsdim = 1)
+            @test tmp == trueXY
+        end
+    end
+
+    @testset "kerneldiagmatrix" begin
+        X = rand(2, 10)
+        trueval = ones(10)
+        tmp = Vector{Float64}(undef, 10)
+
+        for kernel in (kernel1, kernel2)
+            @test kerneldiagmatrix(kernel, X) == trueval
+            @test kerneldiagmatrix(kernel, X'; obsdim = 1) == trueval
+
+            fill!(tmp, 0)
+            kerneldiagmatrix!(tmp, kernel, X)
+            @test tmp == trueval
+
+            fill!(tmp, 0)
+            kerneldiagmatrix!(tmp, kernel, X'; obsdim = 1)
+            @test tmp == trueval
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,7 @@ using KernelFunctions: metric
         include(joinpath("kernels", "piecewisepolynomial.jl"))
         include(joinpath("kernels", "rationalquad.jl"))
         include(joinpath("kernels", "scaledkernel.jl"))
+        include(joinpath("kernels", "tensorproduct.jl"))
         include(joinpath("kernels", "transformedkernel.jl"))
 
         # Legacy tests that don't correspond to anything meaningful in src. Unclear how


### PR DESCRIPTION
See https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/pull/80#issuecomment-614003196.

As discussed in the outdated PR https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/pull/56#issue-393484992, it is still unclear what type of arguments `kernelmatrix` and `kerneldiagmatrix` should take, or how to implement this in a general way to support both data types (i.e., collections of joint observations in all spaces (e.g., of type `Vector{Tuple{Vector{Float64},Vector{Int}}}`), or collections of collections of observations in each space (e.g., of type `Tuple{Matrix{Float64},Matrix{Int}}`).