### PR TITLE
[WIP] Rework on kernelmatrix to work with Vectors and more complex kernels

### DIFF
--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -10,6 +10,7 @@ export duplicate, set! # Helpers
 
 export Kernel
 export ConstantKernel, WhiteKernel, EyeKernel, ZeroKernel
+export CosineKernel
 export SqExponentialKernel, RBFKernel, GaussianKernel, SEKernel
 export LaplacianKernel, ExponentialKernel, GammaExponentialKernel
 export ExponentiatedKernel

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -41,6 +41,7 @@ Abstract type defining a slice-wise transformation on an input matrix
 abstract type Transform end
 abstract type Kernel end
 abstract type BaseKernel <: Kernel end
+abstract type SimpleKernel <: BaseKernel end
 
 include("utils.jl")
 include("distances/dotproduct.jl")

--- a/src/basekernels/constant.jl
+++ b/src/basekernels/constant.jl
@@ -7,7 +7,7 @@ Create a kernel that always returning zero
 ```
 The output type depends of `x` and `y`
 """
-struct ZeroKernel <: BaseKernel end
+struct ZeroKernel <: SimpleKernel end
 
 kappa(κ::ZeroKernel, d::T) where {T<:Real} = zero(T)
 
@@ -15,6 +15,7 @@ metric(::ZeroKernel) = Delta()
 
 Base.show(io::IO, ::ZeroKernel) = print(io, "Zero Kernel")
 
+issimple(ZeroKernel) = true
 
 """
     WhiteKernel()
@@ -24,7 +25,7 @@ Base.show(io::IO, ::ZeroKernel) = print(io, "Zero Kernel")
 ```
 Kernel function working as an equivalent to add white noise. Can also be called via `EyeKernel()`
 """
-struct WhiteKernel <: BaseKernel end
+struct WhiteKernel <: SimpleKernel end
 
 """
     EyeKernel()
@@ -48,7 +49,7 @@ Kernel function always returning a constant value `c`
     κ(x,y) = c
 ```
 """
-struct ConstantKernel{Tc<:Real} <: BaseKernel
+struct ConstantKernel{Tc<:Real} <: SimpleKernel
     c::Vector{Tc}
     function ConstantKernel(;c::T=1.0) where {T<:Real}
         new{T}([c])

--- a/src/basekernels/constant.jl
+++ b/src/basekernels/constant.jl
@@ -15,7 +15,6 @@ metric(::ZeroKernel) = Delta()
 
 Base.show(io::IO, ::ZeroKernel) = print(io, "Zero Kernel")
 
-issimple(ZeroKernel) = true
 
 """
     WhiteKernel()

--- a/src/basekernels/cosine.jl
+++ b/src/basekernels/cosine.jl
@@ -6,7 +6,7 @@ The cosine kernel is a stationary kernel for a sinusoidal given by
     κ(x,y) = cos( π * (x-y) )
 ```
 """
-struct CosineKernel <: BaseKernel end
+struct CosineKernel <: SimpleKernel end
 
 kappa(κ::CosineKernel, d::Real) = cospi(d)
 metric(::CosineKernel) = Euclidean()

--- a/src/basekernels/exponential.jl
+++ b/src/basekernels/exponential.jl
@@ -9,7 +9,7 @@ Can also be called via `SEKernel`, `GaussianKernel` or `SEKernel`.
 See also [`ExponentialKernel`](@ref) for a
 related form of the kernel or [`GammaExponentialKernel`](@ref) for a generalization.
 """
-struct SqExponentialKernel <: BaseKernel end
+struct SqExponentialKernel <: SimpleKernel end
 
 kappa(κ::SqExponentialKernel, d²::Real) = exp(-d²)
 iskroncompatible(::SqExponentialKernel) = true
@@ -30,7 +30,7 @@ The exponential kernel is a Mercer kernel given by the formula:
     κ(x,y) = exp(-‖x-y‖)
 ```
 """
-struct ExponentialKernel <: BaseKernel end
+struct ExponentialKernel <: SimpleKernel end
 
 kappa(κ::ExponentialKernel, d::Real) = exp(-d)
 iskroncompatible(::ExponentialKernel) = true
@@ -51,7 +51,7 @@ The γ-exponential kernel is an isotropic Mercer kernel given by the formula:
 Where `γ > 0`, (the keyword `γ` can be replaced by `gamma`)
 For `γ = 1`, see `SqExponentialKernel` and `γ = 0.5`, see `ExponentialKernel`
 """
-struct GammaExponentialKernel{Tγ<:Real} <: BaseKernel
+struct GammaExponentialKernel{Tγ<:Real} <: SimpleKernel
     γ::Vector{Tγ}
     function GammaExponentialKernel(; gamma::T=2.0, γ::T=gamma) where {T<:Real}
         @check_args(GammaExponentialKernel, γ, γ >= zero(T), "γ > 0")

--- a/src/basekernels/exponentiated.jl
+++ b/src/basekernels/exponentiated.jl
@@ -6,7 +6,7 @@ The exponentiated kernel is a Mercer kernel given by:
     κ(x,y) = exp(xᵀy)
 ```
 """
-struct ExponentiatedKernel <: BaseKernel end
+struct ExponentiatedKernel <: SimpleKernel end
 
 kappa(κ::ExponentiatedKernel, xᵀy::Real) = exp(xᵀy)
 metric(::ExponentiatedKernel) = DotProduct()

--- a/src/basekernels/fbm.jl
+++ b/src/basekernels/fbm.jl
@@ -66,17 +66,6 @@ function kernelmatrix!(
     return K
 end
 
-## Apply kernel on two vectors ##
-function _kernel(
-        κ::FBMKernel,
-        x::AbstractVector,
-        y::AbstractVector;
-        obsdim::Int = defaultobs
-    )
-    @assert length(x) == length(y) "x and y don't have the same dimension!"
-    return kappa(κ, x, y)
-end
-
 function kappa(κ::FBMKernel, x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
     modX = sum(abs2, x)
     modY = sum(abs2, y)

--- a/src/basekernels/maha.jl
+++ b/src/basekernels/maha.jl
@@ -8,7 +8,7 @@ Mahalanobis distance-based kernel given by
 where the matrix P is the metric.
 
 """
-struct MahalanobisKernel{T<:Real, A<:AbstractMatrix{T}} <: BaseKernel
+struct MahalanobisKernel{T<:Real, A<:AbstractMatrix{T}} <: SimpleKernel
     P::A
     function MahalanobisKernel(P::AbstractMatrix{T}) where {T<:Real}
         LinearAlgebra.checksquare(P)

--- a/src/basekernels/matern.jl
+++ b/src/basekernels/matern.jl
@@ -7,7 +7,7 @@ The matern kernel is a Mercer kernel given by the formula:
 ```
 For `ν=n+1/2, n=0,1,2,...` it can be simplified and you should instead use [`ExponentialKernel`](@ref) for `n=0`, [`Matern32Kernel`](@ref), for `n=1`, [`Matern52Kernel`](@ref) for `n=2` and [`SqExponentialKernel`](@ref) for `n=∞`.
 """
-struct MaternKernel{Tν<:Real} <: BaseKernel
+struct MaternKernel{Tν<:Real} <: SimpleKernel
     ν::Vector{Tν}
     function MaternKernel(;nu::T=1.5, ν::T=nu) where {T<:Real}
         @check_args(MaternKernel, ν, ν > zero(T), "ν > 0")
@@ -37,7 +37,7 @@ The matern 3/2 kernel is a Mercer kernel given by the formula:
     κ(x,y) = (1+√(3)‖x-y‖)exp(-√(3)‖x-y‖)
 ```
 """
-struct Matern32Kernel <: BaseKernel end
+struct Matern32Kernel <: SimpleKernel end
 
 kappa(κ::Matern32Kernel, d::Real) = (1 + sqrt(3) * d) * exp(-sqrt(3) * d)
 metric(::Matern32Kernel) = Euclidean()
@@ -52,7 +52,7 @@ The matern 5/2 kernel is a Mercer kernel given by the formula:
     κ(x,y) = (1+√(5)‖x-y‖ + 5/3‖x-y‖^2)exp(-√(5)‖x-y‖)
 ```
 """
-struct Matern52Kernel <: BaseKernel end
+struct Matern52Kernel <: SimpleKernel end
 
 kappa(κ::Matern52Kernel, d::Real) = (1 + sqrt(5) * d + 5 * d^2 / 3) * exp(-sqrt(5) * d)
 metric(::Matern52Kernel) = Euclidean()

--- a/src/basekernels/periodic.jl
+++ b/src/basekernels/periodic.jl
@@ -8,7 +8,7 @@ Periodic Kernel as described in http://www.inference.org.uk/mackay/gpB.pdf eq. 4
     κ(x,y) = exp( - 0.5 sum_i(sin (π(x_i - y_i))/r_i))
 ```
 """
-struct PeriodicKernel{T} <: BaseKernel
+struct PeriodicKernel{T} <: SimpleKernel
     r::Vector{T}
     function PeriodicKernel(; r::AbstractVector{T} = ones(Float64, 1)) where {T<:Real}
         @assert all(r .> 0)

--- a/src/basekernels/piecewisepolynomial.jl
+++ b/src/basekernels/piecewisepolynomial.jl
@@ -43,16 +43,6 @@ function kappa(
     return _piecewisepolynomial(κ, r, j)
 end
 
-function _kernel(
-    κ::PiecewisePolynomialKernel,
-    x::AbstractVector,
-    y::AbstractVector;
-    obsdim::Int = defaultobs,
-)
-    @assert length(x) == length(y) "x and y don't have the same dimension!"
-    return kappa(κ,x,y)
-end
-
 function kernelmatrix(
     κ::PiecewisePolynomialKernel{V},
     X::AbstractMatrix;

--- a/src/basekernels/piecewisepolynomial.jl
+++ b/src/basekernels/piecewisepolynomial.jl
@@ -52,6 +52,17 @@ function kernelmatrix(
     return map(r->_piecewisepolynomial(κ, r, j), pairwise(metric(κ), X; dims=obsdim))
 end
 
+function kernelmatrix(
+    κ::PiecewisePolynomialKernel{V},
+    X::AbstractMatrix,
+    Y::AbstractMatrix;
+    obsdim::Int = defaultobs
+) where {V}
+    j = div(size(X, feature_dim(obsdim)), 2) + V + 1
+    return map(r->_piecewisepolynomial(κ, r, j), pairwise(metric(κ), X, Y; dims=obsdim))
+end
+
+
 function _kernelmatrix(κ::PiecewisePolynomialKernel{V}, X, Y, obsdim) where {V}
     j = div(size(X, feature_dim(obsdim)), 2) + V + 1
     return map(r->_piecewisepolynomial(κ, r, j), pairwise(metric(κ), X, Y; dims=obsdim))

--- a/src/basekernels/piecewisepolynomial.jl
+++ b/src/basekernels/piecewisepolynomial.jl
@@ -12,7 +12,7 @@ where `r` is the Mahalanobis distance mahalanobis(x,y) with `maha` as the metric
 """
 struct PiecewisePolynomialKernel{V, A<:AbstractMatrix{<:Real}} <: SimpleKernel
     maha::A
-    j::Int64
+    j::Int
     function PiecewisePolynomialKernel{V}(maha::AbstractMatrix{<:Real}) where V
         V in (0, 1, 2, 3) || error("Invalid paramter v=$(V). Should be 0, 1, 2 or 3.")
         LinearAlgebra.checksquare(maha)
@@ -31,11 +31,7 @@ _f(κ::PiecewisePolynomialKernel{2}, r, j) = 1 + (j + 2) * r + (j^2 + 4 * j + 3)
 _f(κ::PiecewisePolynomialKernel{3}, r, j) = 1 + (j + 3) * r +
     (6 * j^2 + 36j + 45) / 15 * r.^2 + (j^3 + 9 * j^2 + 23j + 15) / 15 * r.^3
 
-function _piecewisepolynomial(κ::PiecewisePolynomialKernel{V}, r, j) where V
-    return max(1 - r, 0)^(j + V) * _f(κ, r, j)
-end
-
-kappa(κ::PiecewisePolynomialKernel, d::Real) = _piecewisepolynomial(κ, r, κ.j)
+kappa(κ::PiecewisePolynomialKernel{V}, r) where V = max(1 - r, 0)^(κ.j + V) * _f(κ, r, κ.j)
 
 metric(κ::PiecewisePolynomialKernel) = Mahalanobis(κ.maha)
 

--- a/src/basekernels/piecewisepolynomial.jl
+++ b/src/basekernels/piecewisepolynomial.jl
@@ -10,12 +10,14 @@ processes are hence v times  mean-square differentiable. The kernel function is:
 where `r` is the Mahalanobis distance mahalanobis(x,y) with `maha` as the metric.
 
 """
-struct PiecewisePolynomialKernel{V, A<:AbstractMatrix{<:Real}} <: BaseKernel
+struct PiecewisePolynomialKernel{V, A<:AbstractMatrix{<:Real}} <: SimpleKernel
     maha::A
+    j::Int64
     function PiecewisePolynomialKernel{V}(maha::AbstractMatrix{<:Real}) where V
         V in (0, 1, 2, 3) || error("Invalid paramter v=$(V). Should be 0, 1, 2 or 3.")
         LinearAlgebra.checksquare(maha)
-        return new{V,typeof(maha)}(maha)
+        j = div(size(maha, 1), 2) + V + 1
+        return new{V,typeof(maha)}(maha, j)
     end
 end
 
@@ -33,75 +35,7 @@ function _piecewisepolynomial(κ::PiecewisePolynomialKernel{V}, r, j) where V
     return max(1 - r, 0)^(j + V) * _f(κ, r, j)
 end
 
-function kappa(
-    κ::PiecewisePolynomialKernel{V},
-    x::AbstractVector{<:Real},
-    y::AbstractVector{<:Real},
-) where {V}
-    r = evaluate(metric(κ), x, y)
-    j = div(size(x, 2), 1) + V + 1
-    return _piecewisepolynomial(κ, r, j)
-end
-
-function kernelmatrix(
-    κ::PiecewisePolynomialKernel{V},
-    X::AbstractMatrix;
-    obsdim::Int = defaultobs
-) where {V}
-    j = div(size(X, feature_dim(obsdim)), 2) + V + 1
-    return map(r->_piecewisepolynomial(κ, r, j), pairwise(metric(κ), X; dims=obsdim))
-end
-
-function kernelmatrix(
-    κ::PiecewisePolynomialKernel{V},
-    X::AbstractMatrix,
-    Y::AbstractMatrix;
-    obsdim::Int = defaultobs
-) where {V}
-    j = div(size(X, feature_dim(obsdim)), 2) + V + 1
-    return map(r->_piecewisepolynomial(κ, r, j), pairwise(metric(κ), X, Y; dims=obsdim))
-end
-
-
-function _kernelmatrix(κ::PiecewisePolynomialKernel{V}, X, Y, obsdim) where {V}
-    j = div(size(X, feature_dim(obsdim)), 2) + V + 1
-    return map(r->_piecewisepolynomial(κ, r, j), pairwise(metric(κ), X, Y; dims=obsdim))
-end
-
-function kernelmatrix!(
-    K::AbstractMatrix,
-    κ::PiecewisePolynomialKernel{V},
-    X::AbstractMatrix;
-    obsdim::Int = defaultobs
-) where {V}
-    @assert obsdim ∈ [1,2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
-    if !check_dims(K, X, X, feature_dim(obsdim), obsdim)
-        throw(DimensionMismatch(
-            "Dimensions of the target array K $(size(K)) are not consistent with X " *
-            "$(size(X))",
-        ))
-    end
-    j = div(size(X, feature_dim(obsdim)), 2) + V + 1
-    return map!(r->_piecewisepolynomial(κ,r,j), K, pairwise(metric(κ), X; dims=obsdim))
-end
-
-function kernelmatrix!(
-    K::AbstractMatrix,
-    κ::PiecewisePolynomialKernel{V},
-    X::AbstractMatrix,
-    Y::AbstractMatrix;
-    obsdim::Int = defaultobs,
-) where {V}
-    @assert obsdim ∈ [1,2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
-    if !check_dims(K, X, Y, feature_dim(obsdim), obsdim)
-        throw(DimensionMismatch(
-            "Dimensions $(size(K)) of the target array K are not consistent with X " *
-            "($(size(X))) and Y ($(size(Y)))",
-        ))
-    end
-    j = div(size(X, feature_dim(obsdim)), 2) + V + 1
-    return map!(r->_piecewisepolynomial(κ,r,j), K, pairwise(metric(κ), X, Y; dims=obsdim))
-end
+kappa(κ::PiecewisePolynomialKernel, d::Real) = _piecewisepolynomial(κ, r, κ.j)
 
 metric(κ::PiecewisePolynomialKernel) = Mahalanobis(κ.maha)
 

--- a/src/basekernels/polynomial.jl
+++ b/src/basekernels/polynomial.jl
@@ -7,7 +7,7 @@ The linear kernel is a Mercer kernel given by
 ```
 Where `c` is a real number
 """
-struct LinearKernel{Tc<:Real} <: BaseKernel
+struct LinearKernel{Tc<:Real} <: SimpleKernel
     c::Vector{Tc}
     function LinearKernel(;c::T=0.0) where {T}
         new{T}([c])
@@ -28,7 +28,7 @@ The polynomial kernel is a Mercer kernel given by
 ```
 Where `c` is a real number, and `d` is a shape parameter bigger than 1. For `d = 1` see [`LinearKernel`](@ref)
 """
-struct PolynomialKernel{Td<:Real, Tc<:Real} <: BaseKernel
+struct PolynomialKernel{Td<:Real, Tc<:Real} <: SimpleKernel
     d::Vector{Td}
     c::Vector{Tc}
     function PolynomialKernel(; d::Td=2.0, c::Tc=0.0) where {Td<:Real, Tc<:Real}

--- a/src/basekernels/rationalquad.jl
+++ b/src/basekernels/rationalquad.jl
@@ -7,7 +7,7 @@ The rational-quadratic kernel is a Mercer kernel given by the formula:
 ```
 where `α` is a shape parameter of the Euclidean distance. Check [`GammaRationalQuadraticKernel`](@ref) for a generalization.
 """
-struct RationalQuadraticKernel{Tα<:Real} <: BaseKernel
+struct RationalQuadraticKernel{Tα<:Real} <: SimpleKernel
     α::Vector{Tα}
     function RationalQuadraticKernel(;alpha::T=2.0, α::T=alpha) where {T}
         @check_args(RationalQuadraticKernel, α, α > zero(T), "α > 1")
@@ -28,7 +28,7 @@ The Gamma-rational-quadratic kernel is an isotropic Mercer kernel given by the f
 ```
 where `α` is a shape parameter of the Euclidean distance and `γ` is another shape parameter.
 """
-struct GammaRationalQuadraticKernel{Tα<:Real, Tγ<:Real} <: BaseKernel
+struct GammaRationalQuadraticKernel{Tα<:Real, Tγ<:Real} <: SimpleKernel
     α::Vector{Tα}
     γ::Vector{Tγ}
     function GammaRationalQuadraticKernel(;alpha::Tα=2.0, gamma::Tγ=2.0, α::Tα=alpha, γ::Tγ=gamma) where {Tα<:Real, Tγ<:Real}

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -22,7 +22,7 @@ end
 
 for k in concretetypes(Kernel, [])
     @eval begin
-        @inline (κ::$k)(x::AbstractVector{<:Real}, y::AbstractVector{<:Real}) = kappa(κ, x, y)
+        @inline (κ::$k)(x, y) = kappa(κ, x, y)
         @inline (κ::$k)(X::AbstractMatrix{T}, Y::AbstractMatrix{T}; obsdim::Integer=defaultobs) where {T} = kernelmatrix(κ, X, Y, obsdim=obsdim)
         @inline (κ::$k)(X::AbstractMatrix{T}; obsdim::Integer=defaultobs) where {T} = kernelmatrix(κ, X, obsdim=obsdim)
     end

--- a/src/kernels/kernelproduct.jl
+++ b/src/kernels/kernelproduct.jl
@@ -29,23 +29,26 @@ hadamard(x,y) = x.*y
 function kernelmatrix(
     κ::KernelProduct,
     X::AbstractMatrix;
-    obsdim::Int=defaultobs)
-    reduce(hadamard,kernelmatrix(κ.kernels[i],X,obsdim=obsdim) for i in 1:length(κ))
+    obsdim::Int=defaultobs,
+)
+    reduce(hadamard, kernelmatrix(κ.kernels[i], X, obsdim = obsdim) for i in 1:length(κ))
 end
 
 function kernelmatrix(
     κ::KernelProduct,
     X::AbstractMatrix,
     Y::AbstractMatrix;
-    obsdim::Int=defaultobs)
-    reduce(hadamard,_kernelmatrix(κ.kernels[i],X,Y,obsdim) for i in 1:length(κ))
+    obsdim::Int=defaultobs,
+)
+    reduce(hadamard, kernelmatrix(κ.kernels[i], X, Y, obsdim = obsdim) for i in 1:length(κ))
 end
 
 function kerneldiagmatrix(
     κ::KernelProduct,
     X::AbstractMatrix;
-    obsdim::Int=defaultobs) #TODO Add test
-    reduce(hadamard,kerneldiagmatrix(κ.kernels[i],X,obsdim=obsdim) for i in 1:length(κ))
+    obsdim::Int=defaultobs,
+) #TODO Add test
+    reduce(hadamard, kerneldiagmatrix(κ.kernels[i], X, obsdim = obsdim) for i in 1:length(κ))
 end
 
 function Base.show(io::IO, κ::KernelProduct)

--- a/src/kernels/kernelsum.jl
+++ b/src/kernels/kernelsum.jl
@@ -58,7 +58,7 @@ function kernelmatrix(
     Y::AbstractMatrix;
     obsdim::Int = defaultobs,
 )
-    sum(κ.weights[i] * _kernelmatrix(κ.kernels[i], X, Y, obsdim) for i in 1:length(κ))
+    sum(κ.weights[i] * kernelmatrix(κ.kernels[i], X, Y, obsdim = obsdim) for i in 1:length(κ))
 end
 
 function kerneldiagmatrix(

--- a/src/kernels/scaledkernel.jl
+++ b/src/kernels/scaledkernel.jl
@@ -15,6 +15,8 @@ end
 
 kappa(k::ScaledKernel, x) = first(k.σ²) * kappa(k.kernel, x)
 
+kappa(k::ScaledKernel, x, y) = first(k.σ²) * kappa(k.kernel, x, y)
+
 metric(k::ScaledKernel) = metric(k.kernel)
 
 Base.:*(w::Real, k::Kernel) = ScaledKernel(k, w)

--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -22,7 +22,6 @@ end
 
 Base.length(kernel::TensorProduct) = length(kernel.kernels)
 
-(kernel::TensorProduct)(x, y) = kappa(kernel, x, y)
 function kappa(kernel::TensorProduct, x, y)
     return prod(kappa(k, xi, yi) for (k, xi, yi) in zip(kernel.kernels, x, y))
 end

--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -96,7 +96,7 @@ function kernelmatrix(
     obsdim ∈ (1, 2) || error("obsdim should be 1 or 2 (see docs of kernelmatrix))")
 
     featuredim = feature_dim(obsdim)
-    if !check_dims(X, X, featuredim, obsdim)
+    if !check_dims(X, X, featuredim)
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not " *
                                 "consistent with X $(size(X))"))
     end
@@ -119,7 +119,7 @@ function kernelmatrix(
     obsdim ∈ (1, 2) || error("obsdim should be 1 or 2 (see docs of kernelmatrix))")
 
     featuredim = feature_dim(obsdim)
-    if !check_dims(X, Y, featuredim, obsdim)
+    if !check_dims(X, Y, featuredim)
         throw(DimensionMismatch("Dimensions $(size(K)) of the target array K are not " *
                                 "consistent with X ($(size(X))) and Y ($(size(Y)))"))
     end

--- a/src/kernels/transformedkernel.jl
+++ b/src/kernels/transformedkernel.jl
@@ -39,3 +39,17 @@ function printshifted(io::IO, κ::TransformedKernel, shift::Int)
     printshifted(io, κ.kernel, shift)
     print(io,"\n" * ("\t" ^ (shift + 1)) * "- $(κ.transform)")
 end
+
+# Kernel matrix operations
+
+kernelmatrix!(K::AbstractMatrix, κ::TransformedKernel, X::AbstractMatrix; obsdim::Int = defaultobs) =
+    kernelmatrix!(K, kernel(κ), apply(κ.transform, X, obsdim = obsdim), obsdim = obsdim)
+
+kernelmatrix!(K::AbstractMatrix, κ::TransformedKernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim::Int = defaultobs) =
+    kernelmatrix!(K, kernel(κ), apply(κ.transform, X, obsdim = obsdim), apply(κ.transform, Y, obsdim = obsdim), obsdim = obsdim)
+
+kernelmatrix(κ::TransformedKernel, X::AbstractMatrix; obsdim::Int = defaultobs) =
+    kernelmatrix(kernel(κ), apply(κ.transform, X, obsdim = obsdim), obsdim = obsdim)
+    
+kernelmatrix(κ::TransformedKernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim::Int = defaultobs) =
+    kernelmatrix(kernel(κ), apply(κ.transform, X, obsdim = obsdim), apply(κ.transform, Y, obsdim = obsdim), obsdim = obsdim)

--- a/src/matrix/kernelkroneckermat.jl
+++ b/src/matrix/kernelkroneckermat.jl
@@ -8,8 +8,8 @@ function kernelkronmat(
     dims::Int
     )
     @assert iskroncompatible(κ) "The chosen kernel is not compatible for kroenecker matrices (see `iskroncompatible()`)"
-    k = kernelmatrix(κ,reshape(X,:,1),obsdim=1)
-    kronecker(k,dims)
+    k = kernelmatrix(κ, X)
+    kronecker(k, dims)
 end
 
 function kernelkronmat(
@@ -18,8 +18,8 @@ function kernelkronmat(
     obsdim::Int=defaultobs
     )
     @assert iskroncompatible(κ) "The chosen kernel is not compatible for kroenecker matrices"
-    Ks = kernelmatrix.(κ,X,obsdim=obsdim)
-    K = reduce(⊗,Ks)
+    Ks = kernelmatrix.(κ, X)
+    K = reduce(⊗, Ks)
 end
 
 

--- a/src/matrix/kernelmatrix.jl
+++ b/src/matrix/kernelmatrix.jl
@@ -12,7 +12,7 @@ function kernelmatrix!(
     κ::Kernel,
     X::AbstractVector{<:Real}
 )
-    kernelmatrix!(K, κ, reshape(X, 1, :), obsdim = 2)
+    kernelmatrix!(K, κ, ColVecs(reshape(X, 1, :)))
 end
 
 function kernelmatrix!(
@@ -47,7 +47,7 @@ function kernelmatrix!(
     κ::Kernel,
     X::AbstractVector
     )
-    if (size(K, 1) != size(K, 2)) || (length(X) != size(K, 1))
+    if !check_dims(K, X, X)
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
     end
     K .= κ.(X, X')
@@ -60,7 +60,7 @@ function kernelmatrix!(
     X::AbstractVector{<:Real},
     Y::AbstractVector{<:Real}
 )
-    kernelmatrix!(K, κ, reshape(X, 1, :), reshape(Y, 1, :), obsdim = 2)
+    kernelmatrix!(K, κ, ColVecs(reshape(X, 1, :)), ColVecs(reshape(Y, 1, :)))
 end
 
 function kernelmatrix!(
@@ -98,7 +98,7 @@ function kernelmatrix!(
     X::AbstractVector,
     Y::AbstractVector
     )
-    if (size(K, 1) != length(X)) || (size(K, 2) != length(Y))
+    if !check_dims(K, X, Y)
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X)) and Y $(size(Y))"))
     end
     K .= κ.(X, Y')
@@ -147,9 +147,9 @@ end
 function kernelmatrix(
     κ::Kernel,
     X::AbstractVector{<:Real},
-    Y::AbstractMatrix{<:Real}
+    Y::AbstractVector{<:Real}
     )
-    kernelmatrix(κ, reshape(X, 1, :), reshape(Y, 1, :), obsdim = 2)
+    kernelmatrix(κ, ColVecs(reshape(X, 1, :)), ColVecs(reshape(Y, 1, :)))
 end
 
 function kernelmatrix(
@@ -231,5 +231,8 @@ function kerneldiagmatrix!(
     κ::Kernel,
     X::AbstractVector
     )
+    if length(K) != length(X)
+        throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(length(X))"))
+    end
     map!(κ, K, X, X)
 end

--- a/src/matrix/kernelmatrix.jl
+++ b/src/matrix/kernelmatrix.jl
@@ -25,7 +25,6 @@ function kernelmatrix!(
     X::AbstractMatrix;
     obsdim::Int = defaultobs
 )
-    @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
     kernelmatrix!(K, κ, vec_of_vecs(X, obsdim = obsdim))
 end
 
@@ -61,7 +60,6 @@ function kernelmatrix!(
     Y::AbstractMatrix;
     obsdim::Int = defaultobs
 )
-    @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
     kernelmatrix!(K, κ, vec_of_vecs(X, obsdim = obsdim), vec_of_vecs(Y, obsdim = obsdim))
 
 end
@@ -102,7 +100,6 @@ function kernelmatrix(κ::SimpleKernel, X::AbstractMatrix; obsdim::Int = default
 end
 
 function kernelmatrix(κ::Kernel, X::AbstractMatrix; obsdim::Int = defaultobs)
-    @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
     kernelmatrix(κ, vec_of_vecs(X, obsdim = obsdim))
 end
 
@@ -120,7 +117,6 @@ function kernelmatrix(
 end
 
 function kernelmatrix(κ::Kernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim::Int = defaultobs)
-    @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
     kernelmatrix(κ, vec_of_vecs(X, obsdim = obsdim), vec_of_vecs(Y, obsdim = obsdim))
 end
 
@@ -138,7 +134,6 @@ function kerneldiagmatrix(
     X::AbstractMatrix;
     obsdim::Int = defaultobs
     )
-    @assert obsdim ∈ [1,2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
     kerneldiagmatrix(κ, vec_of_vecs(X, obsdim = obsdim))
 end
 
@@ -157,7 +152,6 @@ function kerneldiagmatrix!(
     X::AbstractMatrix;
     obsdim::Int = defaultobs
     )
-    @assert obsdim ∈ [1,2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
     if length(K) != size(X,obsdim)
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
     end

--- a/src/matrix/kernelmatrix.jl
+++ b/src/matrix/kernelmatrix.jl
@@ -6,58 +6,81 @@ In-place version of [`kernelmatrix`](@ref) where pre-allocated matrix `K` will b
 """
 kernelmatrix!
 
+function kernelmatrix!(
+    K::AbstractMatrix,
+    κ::SimpleKernel,
+    X::AbstractMatrix;
+    obsdim::Int = defaultobs,
+)
+    @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
+    if !check_dims(K, X, X, feature_dim(obsdim), obsdim)
+        throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
+    end
+    map!(x -> kappa(κ, x), K, pairwise(metric(κ), X, dims = obsdim))
+end
 
 function kernelmatrix!(
-        K::AbstractMatrix,
-        κ::Kernel,
-        X::AbstractMatrix;
-        obsdim::Int = defaultobs
-        )
-        @assert obsdim ∈ [1,2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
-        if !check_dims(K,X,X,feature_dim(obsdim),obsdim)
-            throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
-        end
-        map!(x->kappa(κ,x),K,pairwise(metric(κ),X,dims=obsdim))
+    K::AbstractMatrix,
+    κ::BaseKernel,
+    X::AbstractMatrix;
+    obsdim::Int = defaultobs
+)
+    @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
+    if obsdim == 1
+        @compat kernelmatrix!(K, κ, ColVecs(X))
+    else
+        @compat kernelmatrix!(K, κ, RowVecs(X))
+    end
 end
-
-kernelmatrix!(K::AbstractMatrix, κ::TransformedKernel, X::AbstractMatrix; obsdim::Int = defaultobs) =
-        kernelmatrix!(K, kernel(κ), apply(κ.transform, X, obsdim = obsdim), obsdim = obsdim)
 
 function kernelmatrix!(
-        K::AbstractMatrix,
-        κ::Kernel,
-        X::AbstractMatrix,
-        Y::AbstractMatrix;
-        obsdim::Int = defaultobs
-        )
-        @assert obsdim ∈ [1,2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
-        if !check_dims(K,X,Y,feature_dim(obsdim),obsdim)
-            throw(DimensionMismatch("Dimensions $(size(K)) of the target array K are not consistent with X ($(size(X))) and Y ($(size(Y)))"))
-        end
-        map!(x->kappa(κ,x),K,pairwise(metric(κ),X,Y,dims=obsdim))
-end
-
-kernelmatrix!(K::AbstractMatrix, κ::TransformedKernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim::Int = defaultobs) =
-        kernelmatrix!(K, kernel(κ), apply(κ.transform, X, obsdim = obsdim), apply(κ.transform, Y, obsdim = obsdim), obsdim = obsdim)
-
-## Apply kernel on two reals ##
-function _kernel(κ::Kernel, x::Real, y::Real)
-    _kernel(κ, [x], [y])
-end
-
-## Apply kernel on two vectors ##
-function _kernel(
-        κ::Kernel,
-        x::AbstractVector,
-        y::AbstractVector;
-        obsdim::Int = defaultobs
+    K::AbstractMatrix,
+    κ::BaseKernel,
+    X::AbstractVector
     )
-    @assert length(x) == length(y) "x and y don't have the same dimension!"
-    kappa(κ, evaluate(metric(κ),x,y))
+    if !check_dims(K, X, X, feature_dim(obsdim), obsdim)
+        throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
+    end
+    map!(κ, K, X, X')
 end
 
-_kernel(κ::TransformedKernel, x::AbstractVector, y::AbstractVector; obsdim::Int = defaultobs) =
-        _kernel(kernel(κ), apply(κ.transform, x), apply(κ.transform, y), obsdim = obsdim)
+function kernelmatrix!(
+    K::AbstractMatrix,
+    κ::SimpleKernel,
+    X::AbstractMatrix,
+    Y::AbstractMatrix;
+    obsdim::Int = defaultobs,
+)
+    @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
+    if !check_dims(K, X, Y, feature_dim(obsdim), obsdim)
+        throw(DimensionMismatch("Dimensions $(size(K)) of the target array K are not consistent with X ($(size(X))) and Y ($(size(Y)))"))
+    end
+    map!(κ, K, pairwise(metric(κ), X, Y, dims = obsdim))
+end
+
+function kernelmatrix!(
+    K::AbstractMatrix,
+    κ::BaseKernel,
+    X::AbstractMatrix,
+    Y::AbstractMatrix;
+    obsdim::Int = defaultobs
+)
+    @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
+    if obsdim == 1
+        @compat kernelmatrix!(K, κ, ColVecs(X), ColVecs(Y))
+    else
+        @compat kernelmatrix!(K, κ, RowVecs(X), RowVecs(Y))
+    end
+end
+
+function kernelmatrix!(
+    K::AbstractMatrix,
+    κ::BaseKernel,
+    X::AbstractVector,
+    Y::AbstractVector
+    )
+    map!(K, κ, X, Y')
+end
 
 """
     kernelmatrix(κ::Kernel, X::Matrix; obsdim::Int = 2)
@@ -70,42 +93,52 @@ Calculate the kernel matrix of `X` (and `Y`) with respect to kernel `κ`.
 kernelmatrix
 
 function kernelmatrix(
-        κ::Kernel,
-        X::AbstractVector{<:Real};
-        obsdim::Int=defaultobs
-        )
-        kernelmatrix(κ,reshape(X,1,:),obsdim=2)
+    κ::Kernel,
+    X::AbstractVector{<:Real};
+    obsdim::Int = defaultobs,
+)
+    kernelmatrix(κ, reshape(X, 1, :), obsdim = 2)
+end
+
+function kernelmatrix(κ::Kernel, X::AbstractVector)
+    kernelmatrix(κ, X, X) #TODO Can be optimized later
+end
+
+function kernelmatrix(κ::Kernel, X::AbstractVector, Y::AbstractVector)
+    κ.(X, Y')
+end
+
+
+
+function kernelmatrix(κ::SimpleKernel, X::AbstractMatrix; obsdim::Int = defaultobs)
+    @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
+    K = map(x -> kappa(κ, x), pairwise(metric(κ), X, dims = obsdim))
+end
+
+function kernelmatrix(κ::Kernel, X::AbstractMatrix; obsdim::Int = defaultobs)
+    @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
+    if obsdim == 1
+        kernelmatrix(κ, ColVecs(X))
+    else
+        kernelmatrix(κ, RowVecs(X))
+    end
 end
 
 function kernelmatrix(
-        κ::Kernel,
-        X::AbstractMatrix;
-        obsdim::Int = defaultobs
-        )
-        K = map(x->kappa(κ,x),pairwise(metric(κ),X,dims=obsdim))
-end
-
-kernelmatrix(κ::TransformedKernel, X::AbstractMatrix; obsdim::Int = defaultobs) =
-        kernelmatrix(kernel(κ), apply(κ.transform, X, obsdim = obsdim), obsdim = obsdim)
-
-function kernelmatrix(
-        κ::Kernel,
-        X::AbstractMatrix,
-        Y::AbstractMatrix;
-        obsdim=defaultobs
-    )
-    @assert obsdim ∈ [1,2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
-    if !check_dims(X,Y,feature_dim(obsdim),obsdim)
+    κ::SimpleKernel,
+    X::AbstractMatrix,
+    Y::AbstractMatrix;
+    obsdim = defaultobs,
+)
+    @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
+    if !check_dims(X, Y, feature_dim(obsdim), obsdim)
         throw(DimensionMismatch("X $(size(X)) and Y $(size(Y)) do not have the same number of features on the dimension : $(feature_dim(obsdim))"))
     end
-    _kernelmatrix(κ,X,Y,obsdim)
+    _kernelmatrix(κ, X, Y, obsdim)
 end
 
 @inline _kernelmatrix(κ::SimpleKernel, X, Y, obsdim) =
-        map(x -> kappa(κ, x), pairwise(metric(κ), X, Y, dims = obsdim))
-
-kernelmatrix(κ::TransformedKernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim::Int = defaultobs) =
-        kernelmatrix(kernel(κ), apply(κ.transform, X, obsdim = obsdim), apply(κ.transform, Y, obsdim = obsdim), obsdim = obsdim)
+    map(x -> kappa(κ, x), pairwise(metric(κ), X, Y, dims = obsdim))
 
 """
     kerneldiagmatrix(κ::Kernel, X::Matrix; obsdim::Int = 2)
@@ -115,16 +148,20 @@ Calculate the diagonal matrix of `X` with respect to kernel `κ`
 `obsdim = 2` means the matrix `X` has size #dimension x #samples
 """
 function kerneldiagmatrix(
-        κ::Kernel,
-        X::AbstractMatrix;
-        obsdim::Int = defaultobs
-        )
-        @assert obsdim ∈ [1,2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
-        if obsdim == 1
-            @compat eachrow(X) .|> x-> κ(x, x) #[@views _kernel(κ,X[i,:],X[i,:]) for i in 1:size(X,obsdim)]
-        elseif obsdim == 2
-            @compat eachcol(X) .|> x-> κ(x, x) #[@views _kernel(κ,X[:,i],X[:,i]) for i in 1:size(X,obsdim)]
-        end
+    κ::Kernel,
+    X::AbstractMatrix;
+    obsdim::Int = defaultobs
+    )
+    @assert obsdim ∈ [1,2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
+    if obsdim == 1
+        @compat kerneldiagmatrix(κ, ColVecs(X)) #[@views _kernel(κ,X[i,:],X[i,:]) for i in 1:size(X,obsdim)]
+    elseif obsdim == 2
+        @compat kerneldiagmatrix(κ, RowVecs(X)) #[@views _kernel(κ,X[:,i],X[:,i]) for i in 1:size(X,obsdim)]
+    end
+end
+
+function kerneldiagmatrix(κ::Kernel, X::AbstractVector)
+    κ.(X, X)
 end
 
 """
@@ -133,23 +170,31 @@ end
 In place version of [`kerneldiagmatrix`](@ref)
 """
 function kerneldiagmatrix!(
-        K::AbstractVector,
-        κ::SimpleKernel,
-        X::AbstractMatrix;
-        obsdim::Int = defaultobs
-        )
-        @assert obsdim ∈ [1,2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
-        if length(K) != size(X,obsdim)
-            throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
+    K::AbstractVector,
+    κ::Kernel,
+    X::AbstractMatrix;
+    obsdim::Int = defaultobs
+    )
+    @assert obsdim ∈ [1,2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
+    if length(K) != size(X,obsdim)
+        throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
+    end
+    if obsdim == 1
+        for i in eachindex(K)
+            @inbounds @views K[i] = κ(X[i,:], X[i,:])
         end
-        if obsdim == 1
-            for i in eachindex(K)
-                @inbounds @views K[i] = κ(X[i,:], X[i,:])
-            end
-        else
-            for i in eachindex(K)
-                @inbounds @views K[i] = κ(X[:,i], X[:,i])
-            end
+    else
+        for i in eachindex(K)
+            @inbounds @views K[i] = κ(X[:,i], X[:,i])
         end
-        return K
+    end
+    return K
+end
+
+function kerneldiagmatrix!(
+    K::AbstractVector,
+    κ::Kernel,
+    X::AbstractVector
+    )
+    map!(κ, K, X, X)
 end

--- a/src/matrix/kernelmatrix.jl
+++ b/src/matrix/kernelmatrix.jl
@@ -21,7 +21,7 @@ function kernelmatrix!(
     X::AbstractMatrix;
     obsdim::Int = defaultobs,
 )
-    @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
+    @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`)"
     if !check_dims(K, X, X, feature_dim(obsdim), obsdim)
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
     end
@@ -181,9 +181,9 @@ function kerneldiagmatrix(
     )
     @assert obsdim ∈ [1,2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
     if obsdim == 1
-        kerneldiagmatrix(κ, ColVecs(X)) #[@views _kernel(κ,X[i,:],X[i,:]) for i in 1:size(X,obsdim)]
+        kerneldiagmatrix(κ, ColVecs(X))
     elseif obsdim == 2
-        kerneldiagmatrix(κ, ColVecs(X')) #[@views _kernel(κ,X[:,i],X[:,i]) for i in 1:size(X,obsdim)]
+        kerneldiagmatrix(κ, ColVecs(X'))
     end
 end
 

--- a/src/matrix/kernelmatrix.jl
+++ b/src/matrix/kernelmatrix.jl
@@ -6,15 +6,6 @@ In-place version of [`kernelmatrix`](@ref) where pre-allocated matrix `K` will b
 """
 kernelmatrix!
 
-## Wrapper for vector of reals
-function kernelmatrix!(
-    K::AbstractMatrix,
-    κ::Kernel,
-    X::AbstractVector{<:Real}
-)
-    kernelmatrix!(K, κ, ColVecs(reshape(X, 1, :)))
-end
-
 function kernelmatrix!(
     K::AbstractMatrix,
     κ::SimpleKernel,
@@ -51,16 +42,6 @@ function kernelmatrix!(
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
     end
     K .= κ.(X, X')
-end
-
-## Wrapper for vector of reals
-function kernelmatrix!(
-    K::AbstractMatrix,
-    κ::Kernel,
-    X::AbstractVector{<:Real},
-    Y::AbstractVector{<:Real}
-)
-    kernelmatrix!(K, κ, ColVecs(reshape(X, 1, :)), ColVecs(reshape(Y, 1, :)))
 end
 
 function kernelmatrix!(
@@ -114,14 +95,6 @@ Calculate the kernel matrix of `X` (and `Y`) with respect to kernel `κ`.
 """
 kernelmatrix
 
-function kernelmatrix(
-    κ::Kernel,
-    X::AbstractVector{<:Real};
-    obsdim::Int = defaultobs,
-)
-    kernelmatrix(κ, reshape(X, 1, :), obsdim = 2)
-end
-
 function kernelmatrix(κ::Kernel, X::AbstractVector)
     kernelmatrix(κ, X, X) #TODO Can be optimized later
 end
@@ -145,21 +118,13 @@ function kernelmatrix(κ::Kernel, X::AbstractMatrix; obsdim::Int = defaultobs)
 end
 
 function kernelmatrix(
-    κ::Kernel,
-    X::AbstractVector{<:Real},
-    Y::AbstractVector{<:Real}
-    )
-    kernelmatrix(κ, ColVecs(reshape(X, 1, :)), ColVecs(reshape(Y, 1, :)))
-end
-
-function kernelmatrix(
     κ::SimpleKernel,
     X::AbstractMatrix,
     Y::AbstractMatrix;
     obsdim = defaultobs,
 )
     @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
-    if !check_dims(X, Y, feature_dim(obsdim), obsdim)
+    if !check_dims(X, Y, feature_dim(obsdim))
         throw(DimensionMismatch("X $(size(X)) and Y $(size(Y)) do not have the same number of features on the dimension : $(feature_dim(obsdim))"))
     end
     _kernelmatrix(κ, X, Y, obsdim)

--- a/src/matrix/kernelmatrix.jl
+++ b/src/matrix/kernelmatrix.jl
@@ -3,6 +3,7 @@
     kernelmatrix!(K::AbstractMatrix, κ::Kernel, X, Y; obsdim::Integer = 2)
 
 In-place version of [`kernelmatrix`](@ref) where pre-allocated matrix `K` will be overwritten with the kernel matrix.
+Will return the computed matrix `K`
 """
 kernelmatrix!
 
@@ -16,7 +17,7 @@ function kernelmatrix!(
     if !check_dims(K, X, X, feature_dim(obsdim), obsdim)
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
     end
-    map!(x -> kappa(κ, x), K, pairwise(metric(κ), X, dims = obsdim))
+    return map!(x -> kappa(κ, x), K, pairwise(metric(κ), X, dims = obsdim))
 end
 
 function kernelmatrix!(
@@ -25,7 +26,7 @@ function kernelmatrix!(
     X::AbstractMatrix;
     obsdim::Int = defaultobs
 )
-    kernelmatrix!(K, κ, vec_of_vecs(X, obsdim = obsdim))
+    return kernelmatrix!(K, κ, vec_of_vecs(X, obsdim = obsdim))
 end
 
 function kernelmatrix!(
@@ -37,6 +38,7 @@ function kernelmatrix!(
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
     end
     K .= κ.(X, X')
+    return K
 end
 
 function kernelmatrix!(
@@ -50,7 +52,7 @@ function kernelmatrix!(
     if !check_dims(K, X, Y, feature_dim(obsdim), obsdim)
         throw(DimensionMismatch("Dimensions $(size(K)) of the target array K are not consistent with X ($(size(X))) and Y ($(size(Y)))"))
     end
-    map!(x -> kappa(κ, x), K, pairwise(metric(κ), X, Y, dims = obsdim))
+    return map!(x -> kappa(κ, x), K, pairwise(metric(κ), X, Y, dims = obsdim))
 end
 
 function kernelmatrix!(
@@ -60,8 +62,7 @@ function kernelmatrix!(
     Y::AbstractMatrix;
     obsdim::Int = defaultobs
 )
-    kernelmatrix!(K, κ, vec_of_vecs(X, obsdim = obsdim), vec_of_vecs(Y, obsdim = obsdim))
-
+    return kernelmatrix!(K, κ, vec_of_vecs(X, obsdim = obsdim), vec_of_vecs(Y, obsdim = obsdim))
 end
 
 function kernelmatrix!(
@@ -74,6 +75,7 @@ function kernelmatrix!(
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X)) and Y $(size(Y))"))
     end
     K .= κ.(X, Y')
+    return K
 end
 
 """
@@ -86,21 +88,17 @@ Calculate the kernel matrix of `X` (and `Y`) with respect to kernel `κ`.
 """
 kernelmatrix
 
-function kernelmatrix(κ::Kernel, X::AbstractVector)
-    kernelmatrix(κ, X, X) #TODO Can be optimized later
-end
+kernelmatrix(κ::Kernel, X::AbstractVector) = kernelmatrix(κ, X, X)
 
-function kernelmatrix(κ::Kernel, X::AbstractVector, Y::AbstractVector)
-    κ.(X, Y')
-end
+kernelmatrix(κ::Kernel, X::AbstractVector, Y::AbstractVector) = κ.(X, Y')
 
 function kernelmatrix(κ::SimpleKernel, X::AbstractMatrix; obsdim::Int = defaultobs)
     @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
-    K = map(x -> kappa(κ, x), pairwise(metric(κ), X, dims = obsdim))
+    return map(x -> kappa(κ, x), pairwise(metric(κ), X, dims = obsdim))
 end
 
 function kernelmatrix(κ::Kernel, X::AbstractMatrix; obsdim::Int = defaultobs)
-    kernelmatrix(κ, vec_of_vecs(X, obsdim = obsdim))
+    return kernelmatrix(κ, vec_of_vecs(X, obsdim = obsdim))
 end
 
 function kernelmatrix(
@@ -113,11 +111,11 @@ function kernelmatrix(
     if !check_dims(X, Y, feature_dim(obsdim))
         throw(DimensionMismatch("X $(size(X)) and Y $(size(Y)) do not have the same number of features on the dimension : $(feature_dim(obsdim))"))
     end
-    map(x -> kappa(κ, x), pairwise(metric(κ), X, Y, dims = obsdim))
+    return map(x -> kappa(κ, x), pairwise(metric(κ), X, Y, dims = obsdim))
 end
 
 function kernelmatrix(κ::Kernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim::Int = defaultobs)
-    kernelmatrix(κ, vec_of_vecs(X, obsdim = obsdim), vec_of_vecs(Y, obsdim = obsdim))
+    return kernelmatrix(κ, vec_of_vecs(X, obsdim = obsdim), vec_of_vecs(Y, obsdim = obsdim))
 end
 
 """
@@ -134,12 +132,10 @@ function kerneldiagmatrix(
     X::AbstractMatrix;
     obsdim::Int = defaultobs
     )
-    kerneldiagmatrix(κ, vec_of_vecs(X, obsdim = obsdim))
+    return kerneldiagmatrix(κ, vec_of_vecs(X, obsdim = obsdim))
 end
 
-function kerneldiagmatrix(κ::Kernel, X::AbstractVector)
-    κ.(X, X)
-end
+kerneldiagmatrix(κ::Kernel, X::AbstractVector) = κ.(X, X)
 
 """
     kerneldiagmatrix!(K::AbstractVector, κ::Kernel, X; obsdim::Int = 2)
@@ -151,21 +147,20 @@ function kerneldiagmatrix!(
     κ::Kernel,
     X::AbstractMatrix;
     obsdim::Int = defaultobs
-    )
+)
     if length(K) != size(X,obsdim)
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
     end
-    kerneldiagmatrix!(K, κ, vec_of_vecs(X, obsdim = obsdim))
-    return K
+    return kerneldiagmatrix!(K, κ, vec_of_vecs(X, obsdim = obsdim))
 end
 
 function kerneldiagmatrix!(
     K::AbstractVector,
     κ::Kernel,
     X::AbstractVector
-    )
+)
     if length(K) != length(X)
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(length(X))"))
     end
-    map!(κ, K, X, X)
+    return map!(κ, K, X, X)
 end

--- a/src/matrix/kernelmatrix.jl
+++ b/src/matrix/kernelmatrix.jl
@@ -24,7 +24,7 @@ function kernelmatrix!(
     K::AbstractMatrix,
     κ::Kernel,
     X::AbstractMatrix;
-    obsdim::Int = defaultobs
+    obsdim::Int = defaultobs,
 )
     return kernelmatrix!(K, κ, vec_of_vecs(X, obsdim = obsdim))
 end
@@ -32,7 +32,7 @@ end
 function kernelmatrix!(
     K::AbstractMatrix,
     κ::Kernel,
-    X::AbstractVector
+    X::AbstractVector,
     )
     if !check_dims(K, X, X)
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
@@ -60,7 +60,7 @@ function kernelmatrix!(
     κ::Kernel,
     X::AbstractMatrix,
     Y::AbstractMatrix;
-    obsdim::Int = defaultobs
+    obsdim::Int = defaultobs,
 )
     return kernelmatrix!(K, κ, vec_of_vecs(X, obsdim = obsdim), vec_of_vecs(Y, obsdim = obsdim))
 end
@@ -69,7 +69,7 @@ function kernelmatrix!(
     K::AbstractMatrix,
     κ::Kernel,
     X::AbstractVector,
-    Y::AbstractVector
+    Y::AbstractVector,
     )
     if !check_dims(K, X, Y)
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X)) and Y $(size(Y))"))
@@ -130,7 +130,7 @@ kerneldiagmatrix
 function kerneldiagmatrix(
     κ::Kernel,
     X::AbstractMatrix;
-    obsdim::Int = defaultobs
+    obsdim::Int = defaultobs,
     )
     return kerneldiagmatrix(κ, vec_of_vecs(X, obsdim = obsdim))
 end
@@ -146,7 +146,7 @@ function kerneldiagmatrix!(
     K::AbstractVector,
     κ::Kernel,
     X::AbstractMatrix;
-    obsdim::Int = defaultobs
+    obsdim::Int = defaultobs,
 )
     if length(K) != size(X,obsdim)
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
@@ -157,7 +157,7 @@ end
 function kerneldiagmatrix!(
     K::AbstractVector,
     κ::Kernel,
-    X::AbstractVector
+    X::AbstractVector,
 )
     if length(K) != length(X)
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(length(X))"))

--- a/src/matrix/kernelmatrix.jl
+++ b/src/matrix/kernelmatrix.jl
@@ -26,11 +26,7 @@ function kernelmatrix!(
     obsdim::Int = defaultobs
 )
     @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
-    if obsdim == 1
-        kernelmatrix!(K, κ, ColVecs(X'))
-    else
-        kernelmatrix!(K, κ, ColVecs(X))
-    end
+    kernelmatrix!(K, κ, vec_of_vecs(X, obsdim = obsdim))
 end
 
 function kernelmatrix!(
@@ -66,11 +62,8 @@ function kernelmatrix!(
     obsdim::Int = defaultobs
 )
     @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
-    if obsdim == 1
-        kernelmatrix!(K, κ, ColVecs(X'), ColVecs(Y'))
-    else
-        kernelmatrix!(K, κ, ColVecs(X), ColVecs(Y))
-    end
+    kernelmatrix!(K, κ, vec_of_vecs(X, obsdim = obsdim), vec_of_vecs(Y, obsdim = obsdim))
+
 end
 
 function kernelmatrix!(
@@ -110,11 +103,7 @@ end
 
 function kernelmatrix(κ::Kernel, X::AbstractMatrix; obsdim::Int = defaultobs)
     @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
-    if obsdim == 1
-        kernelmatrix(κ, ColVecs(X'))
-    else
-        kernelmatrix(κ, ColVecs(X))
-    end
+    kernelmatrix(κ, vec_of_vecs(X, obsdim = obsdim))
 end
 
 function kernelmatrix(
@@ -127,20 +116,13 @@ function kernelmatrix(
     if !check_dims(X, Y, feature_dim(obsdim))
         throw(DimensionMismatch("X $(size(X)) and Y $(size(Y)) do not have the same number of features on the dimension : $(feature_dim(obsdim))"))
     end
-    _kernelmatrix(κ, X, Y, obsdim)
+    map(x -> kappa(κ, x), pairwise(metric(κ), X, Y, dims = obsdim))
 end
 
 function kernelmatrix(κ::Kernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim::Int = defaultobs)
     @assert obsdim ∈ [1, 2] "obsdim should be 1 or 2 (see docs of `kernelmatrix`))"
-    if obsdim == 1
-        kernelmatrix(κ, ColVecs(X'), ColVecs(Y'))
-    else
-        kernelmatrix(κ, ColVecs(X), ColVecs(Y))
-    end
+    kernelmatrix(κ, vec_of_vecs(X, obsdim = obsdim), vec_of_vecs(Y, obsdim = obsdim))
 end
-
-@inline _kernelmatrix(κ::SimpleKernel, X, Y, obsdim) =
-    map(x -> kappa(κ, x), pairwise(metric(κ), X, Y, dims = obsdim))
 
 """
     kerneldiagmatrix(κ::Kernel, X; obsdim::Int = 2)
@@ -157,11 +139,7 @@ function kerneldiagmatrix(
     obsdim::Int = defaultobs
     )
     @assert obsdim ∈ [1,2] "obsdim should be 1 or 2 (see docs of kernelmatrix))"
-    if obsdim == 1
-        kerneldiagmatrix(κ, ColVecs(X'))
-    else
-        kerneldiagmatrix(κ, ColVecs(X))
-    end
+    kerneldiagmatrix(κ, vec_of_vecs(X, obsdim = obsdim))
 end
 
 function kerneldiagmatrix(κ::Kernel, X::AbstractVector)
@@ -183,11 +161,7 @@ function kerneldiagmatrix!(
     if length(K) != size(X,obsdim)
         throw(DimensionMismatch("Dimensions of the target array K $(size(K)) are not consistent with X $(size(X))"))
     end
-    if obsdim == 1
-        kerneldiagmatrix!(K, κ, ColVecs(X'))
-    else
-        kerneldiagmatrix!(K, κ, ColVecs(X))
-    end
+    kerneldiagmatrix!(K, κ, vec_of_vecs(X, obsdim = obsdim))
     return K
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -53,7 +53,7 @@ end
 
 Base.size(D::RowVecs) = (size(D.X, 1),)
 Base.getindex(D::RowVecs, i::Int) = view(D.X, i, :)
-Base.getindex(D::ColVecs, i::CartesianIndex{1}) = view(D.X, i, :)
+Base.getindex(D::RowVecs, i::CartesianIndex{1}) = view(D.X, i, :)
 Base.getindex(D::RowVecs, i) = RowVecs(view(D.X, i, :))
 
 # Take highest Float among possibilities

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,7 +10,7 @@ macro check_args(K, param, cond, desc=string(cond))
 end
 
 function vec_of_vecs(X::AbstractMatrix; obsdim::Int = 2)
-    @assert obsdim ∈ (1, 2) "obsdim should be 1 or 2"
+    @assert obsdim ∈ (1, 2) "obsdim should be 1 or 2, see docs of kernelmatrix"
     if obsdim == 1
         RowVecs(X)
     else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,9 +19,11 @@ end
 #     return T <: Real ? T : Float64
 # end
 
-check_dims(K,X,Y,featdim,obsdim) = check_dims(X,Y,featdim,obsdim) && (size(K) == (size(X,obsdim),size(Y,obsdim)))
+check_dims(K, X, Y, featdim, obsdim) =
+    check_dims(X, Y, featdim, obsdim) &&
+    (size(K) == (size(X, obsdim), size(Y, obsdim)))
 
-check_dims(X,Y,featdim,obsdim) = size(X,featdim) == size(Y,featdim)
+check_dims(X, Y, featdim, obsdim) = size(X, featdim) == size(Y, featdim)
 
 
 feature_dim(obsdim::Int) = obsdim == 1 ? 2 : 1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -66,14 +66,14 @@ Base.getindex(D::RowVecs, i) = RowVecs(view(D.X, i, :))
 # end
 
 function check_dims(K, X::AbstractVector, Y::AbstractVector)
-    size(K) == (length(X), length(Y))
+    return size(K) == (length(X), length(Y))
 end
 
 
 ## Won't be needed with full ColVecs implementation
 function check_dims(K, X::AbstractMatrix, Y::AbstractMatrix, featdim, obsdim)
-    check_dims(X, Y, featdim) &&
-    (size(K) == (size(X, obsdim), size(Y, obsdim)))
+    return check_dims(X, Y, featdim) &&
+        (size(K) == (size(X, obsdim), size(Y, obsdim)))
 end
 
 check_dims(X::AbstractMatrix, Y::AbstractMatrix, featdim) = size(X, featdim) == size(Y, featdim)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -37,11 +37,18 @@ Base.getindex(D::ColVecs, i) = ColVecs(view(D.X, :, i))
 #     return T <: Real ? T : Float64
 # end
 
-check_dims(K, X, Y, featdim, obsdim) =
-    check_dims(X, Y, featdim, obsdim) &&
-    (size(K) == (size(X, obsdim), size(Y, obsdim)))
+function check_dims(K, X::AbstractVector, Y::AbstractVector)
+    size(K) == (length(X), length(Y))
+end
 
-check_dims(X, Y, featdim, obsdim) = size(X, featdim) == size(Y, featdim)
+
+## Won't be needed with full ColVecs implementation
+function check_dims(K, X::AbstractMatrix, Y::AbstractMatrix, featdim, obsdim)
+    check_dims(X, Y, featdim) &&
+    (size(K) == (size(X, obsdim), size(Y, obsdim)))
+end
+
+check_dims(X::AbstractMatrix, Y::AbstractMatrix, featdim) = size(X, featdim) == size(Y, featdim)
 
 
 feature_dim(obsdim::Int) = obsdim == 1 ? 2 : 1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,6 +25,7 @@ end
 
 Base.size(D::ColVecs) = (size(D.X, 2),)
 Base.getindex(D::ColVecs, i::Int) = view(D.X, :, i)
+Base.getindex(D::ColVecs, i::CartesianIndex{1}) = view(D.X, :, i)
 Base.getindex(D::ColVecs, i) = ColVecs(view(D.X, :, i))
 
 # Take highest Float among possibilities

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -53,6 +53,7 @@ end
 
 Base.size(D::RowVecs) = (size(D.X, 1),)
 Base.getindex(D::RowVecs, i::Int) = view(D.X, i, :)
+Base.getindex(D::ColVecs, i::CartesianIndex{1}) = view(D.X, i, :)
 Base.getindex(D::RowVecs, i) = RowVecs(view(D.X, i, :))
 
 # Take highest Float among possibilities

--- a/test/basekernels/exponential.jl
+++ b/test/basekernels/exponential.jl
@@ -35,7 +35,7 @@
         @test repr(k) == "Gamma Exponential Kernel (γ = $(γ))"
 
         #Coherence :
-        @test GammaExponentialKernel(γ=1.0)(v1,v2) ≈ SqExponentialKernel(v1,v2)
-        @test GammaExponentialKernel(γ=0.5)(v1,v2) ≈ ExponentialKernel(v1,v2)
+        @test GammaExponentialKernel(γ=1.0)(v1,v2) ≈ SqExponentialKernel()(v1,v2)
+        @test GammaExponentialKernel(γ=0.5)(v1,v2) ≈ ExponentialKernel()(v1,v2)
     end
 end

--- a/test/basekernels/exponential.jl
+++ b/test/basekernels/exponential.jl
@@ -35,7 +35,7 @@
         @test repr(k) == "Gamma Exponential Kernel (γ = $(γ))"
 
         #Coherence :
-        @test KernelFunctions._kernel(GammaExponentialKernel(γ=1.0),v1,v2) ≈ KernelFunctions._kernel(SqExponentialKernel(),v1,v2)
-        @test KernelFunctions._kernel(GammaExponentialKernel(γ=0.5),v1,v2) ≈ KernelFunctions._kernel(ExponentialKernel(),v1,v2)
+        @test GammaExponentialKernel(γ=1.0)(v1,v2) ≈ SqExponentialKernel(v1,v2)
+        @test GammaExponentialKernel(γ=0.5)(v1,v2) ≈ ExponentialKernel(v1,v2)
     end
 end

--- a/test/basekernels/piecewisepolynomial.jl
+++ b/test/basekernels/piecewisepolynomial.jl
@@ -13,8 +13,8 @@
 
     @test k(v1, v2) ≈ kappa(k, v1, v2) atol=1e-5
     @test typeof(k(v1, v2)) <: Real
-    @test size(k(m1, m2)) == (4, 4)
-    @test size(k(m1)) == (4, 4)
+    @test size(kernelmatrix(k, m1, m2)) == (4, 4)
+    @test size(kernelmatrix(k, m1)) == (4, 4)
 
     A1 = ones(4, 4)
     kernelmatrix!(A1, k, m1, m2)

--- a/test/kernels/custom.jl
+++ b/test/kernels/custom.jl
@@ -1,5 +1,5 @@
 # minimal definition of a custom kernel
-struct MyKernel <: Kernel end
+struct MyKernel <: SimpleKernel end
 
 KernelFunctions.kappa(::MyKernel, d2::Real) = exp(-d2)
 KernelFunctions.metric(::MyKernel) = SqEuclidean()

--- a/test/kernels/tensorproduct.jl
+++ b/test/kernels/tensorproduct.jl
@@ -32,27 +32,27 @@
         tmp = Matrix{Float64}(undef, 10, 10)
 
         for kernel in (kernel1, kernel2)
-            @test kernelmatrix(kernel, X) == trueX
-            @test kernelmatrix(kernel, X'; obsdim = 1) == trueX
+            @test kernelmatrix(kernel, X) ≈ trueX
+            @test kernelmatrix(kernel, X'; obsdim = 1) ≈ trueX
 
-            @test kernelmatrix(kernel, X, Y) == trueXY
-            @test kernelmatrix(kernel, X', Y'; obsdim = 1) == trueXY
+            @test kernelmatrix(kernel, X, Y) ≈ trueXY
+            @test kernelmatrix(kernel, X', Y'; obsdim = 1) ≈ trueXY
 
             fill!(tmp, 0)
             kernelmatrix!(tmp, kernel, X)
-            @test tmp == trueX
+            @test tmp ≈ trueX
 
             fill!(tmp, 0)
             kernelmatrix!(tmp, kernel, X'; obsdim = 1)
-            @test tmp == trueX
+            @test tmp ≈ trueX
 
             fill!(tmp, 0)
             kernelmatrix!(tmp, kernel, X, Y)
-            @test tmp == trueXY
+            @test tmp ≈ trueXY
 
             fill!(tmp, 0)
             kernelmatrix!(tmp, kernel, X', Y'; obsdim = 1)
-            @test tmp == trueXY
+            @test tmp ≈ trueXY
         end
     end
 
@@ -96,10 +96,10 @@
             tmp = Matrix{Float64}(undef, 10, 10)
 
             @test kernelmatrix(kernel, X) == trueX
-            @test kernelmatrix(kernel, X'; obsdim = 1) == trueX
+            @test kernelmatrix(kernel, X'; obsdim = 1) ≈ trueX
 
-            @test kernelmatrix(kernel, X, Y) == trueXY
-            @test kernelmatrix(kernel, X', Y'; obsdim = 1) == trueXY
+            @test kernelmatrix(kernel, X, Y) ≈ trueXY
+            @test kernelmatrix(kernel, X', Y'; obsdim = 1) ≈ trueXY
 
             fill!(tmp, 0)
             kernelmatrix!(tmp, kernel, X)

--- a/test/kernels/tensorproduct.jl
+++ b/test/kernels/tensorproduct.jl
@@ -95,7 +95,7 @@
             trueXY = kernelmatrix(k1, X, Y)
             tmp = Matrix{Float64}(undef, 10, 10)
 
-            @test kernelmatrix(kernel, X) == trueX
+            @test kernelmatrix(kernel, X) ≈ trueX
             @test kernelmatrix(kernel, X'; obsdim = 1) ≈ trueX
 
             @test kernelmatrix(kernel, X, Y) ≈ trueXY
@@ -103,19 +103,19 @@
 
             fill!(tmp, 0)
             kernelmatrix!(tmp, kernel, X)
-            @test tmp == trueX
+            @test tmp ≈ trueX
 
             fill!(tmp, 0)
             kernelmatrix!(tmp, kernel, X'; obsdim = 1)
-            @test tmp == trueX
+            @test tmp ≈ trueX
 
             fill!(tmp, 0)
             kernelmatrix!(tmp, kernel, X, Y)
-            @test tmp == trueXY
+            @test tmp ≈ trueXY
 
             fill!(tmp, 0)
             kernelmatrix!(tmp, kernel, X', Y'; obsdim = 1)
-            @test tmp == trueXY
+            @test tmp ≈ trueXY
         end
 
         @testset "kerneldiagmatrix" begin

--- a/test/matrix/kernelmatrix.jl
+++ b/test/matrix/kernelmatrix.jl
@@ -30,7 +30,7 @@
                 @test kerneldiagmatrix(k,A,obsdim=obsdim) == diag(kernelmatrix(k,A,obsdim=obsdim))
                 @test k(A,B,obsdim=obsdim) == kernelmatrix(k,A,B,obsdim=obsdim)
                 @test k(A,obsdim=obsdim) == kernelmatrix(k,A,obsdim=obsdim)
-                @test KernelFunctions._kernel(k,1.0,2.0) == KernelFunctions._kernel(k,[1.0],[2.0])
+                # @test KernelFunctions._kernel(k,1.0,2.0) == KernelFunctions._kernel(k,[1.0],[2.0])
                 @test_throws DimensionMismatch kernelmatrix(k,A,C,obsdim=obsdim)
             end
         end

--- a/test/matrix/kernelmatrix.jl
+++ b/test/matrix/kernelmatrix.jl
@@ -2,28 +2,50 @@
 
     rng = MersenneTwister(123456)
     dims = [10,5]
-
-    A = rand(rng, dims...)
-    B = rand(rng, dims...)
+    vA = [rand(rng, dims[1]) for _ in 1:dims[2]]
+    A = hcat(vA...)
+    vB = [rand(rng, dims[1]) for _ in 1:dims[2]]
+    B = hcat(vB...)
+    x = rand(rng, dims[1])
+    X = collect(reshape(x, 1, :))
+    y = rand(rng, dims[2])
+    Y = collect(reshape(y, 1 , :))
+    KX = zeros(dims[1], dims[1])
+    KXY = zeros(dims[1], dims[2])
     C = rand(rng, 8, 9)
     K = [zeros(dims[1],dims[1]),zeros(dims[2],dims[2])]
     Kdiag = [zeros(dims[1]),zeros(dims[2])]
     s = rand(rng)
     k = SqExponentialKernel()
+    struct baseSE <: KernelFunctions.BaseKernel end
+    (k::baseSE)(x, y) = exp(-evaluate(SqEuclidean(), x, y))
+    newk = baseSE()
     kt = transform(SqExponentialKernel(),s)
 
     @testset "Kernel Matrix Operations" begin
         @testset "Inplace Kernel Matrix" begin
+            @test kernelmatrix!(KX, k, x) ≈ kernelmatrix!(KX, k, X)
+            @test kernelmatrix!(KXY, k, x, y) ≈ kernelmatrix!(KXY, k, X, Y)
+            @test kernelmatrix!(K[2], k, vA) ≈ kernelmatrix(k, A) atol = 1e-5
+            @test kernelmatrix!(K[2], k, vA, vB) ≈ kernelmatrix(k, A, B) atol = 1e-5
             for obsdim in [1,2]
+                @show obsdim
                 @test kernelmatrix!(K[obsdim], k, A, B, obsdim = obsdim) == kernelmatrix(k, A, B, obsdim = obsdim)
                 @test kernelmatrix!(K[obsdim], k, A, obsdim = obsdim) == kernelmatrix(k, A, obsdim = obsdim)
                 @test kerneldiagmatrix!(Kdiag[obsdim], k, A, obsdim = obsdim) == kerneldiagmatrix(k, A, obsdim = obsdim)
                 @test_throws DimensionMismatch kernelmatrix!(K[obsdim], k, A, C, obsdim=obsdim)
                 @test_throws DimensionMismatch kernelmatrix!(K[obsdim], k, C, obsdim=obsdim)
                 @test_throws DimensionMismatch kerneldiagmatrix!(Kdiag[obsdim], k, C, obsdim=obsdim)
+                @test kernelmatrix!(K[obsdim], newk, A, B, obsdim = obsdim) ≈ kernelmatrix(k, A, B, obsdim = obsdim)
+                @test kernelmatrix!(K[obsdim], newk, A, obsdim = obsdim) ≈ kernelmatrix(k, A, obsdim = obsdim)
+                @test kerneldiagmatrix!(Kdiag[obsdim], newk, A, obsdim = obsdim) ≈ kerneldiagmatrix(k, A, obsdim = obsdim)
             end
         end
         @testset "Kernel matrix" begin
+            @test kernelmatrix(k, x) ≈ kernelmatrix(k, X)
+            @test kernelmatrix(k, x, y) ≈ kernelmatrix(k, X, Y)
+            @test kernelmatrix(k, vA) ≈ kernelmatrix(k, A) atol = 1e-5
+            @test kernelmatrix(k, vA, vB) ≈ kernelmatrix(k, A, B) atol = 1e-5
             for obsdim in [1,2]
                 @test kernelmatrix(k,A,B,obsdim=obsdim) == kappa.(k,pairwise(KernelFunctions.metric(k),A,B,dims=obsdim))
                 @test kernelmatrix(k,A,obsdim=obsdim) == kappa.(k,pairwise(KernelFunctions.metric(k),A,dims=obsdim))
@@ -32,6 +54,9 @@
                 @test k(A,obsdim=obsdim) == kernelmatrix(k,A,obsdim=obsdim)
                 # @test KernelFunctions._kernel(k,1.0,2.0) == KernelFunctions._kernel(k,[1.0],[2.0])
                 @test_throws DimensionMismatch kernelmatrix(k,A,C,obsdim=obsdim)
+                @test kernelmatrix!(K[obsdim], newk, A, B, obsdim = obsdim) ≈ kernelmatrix(k, A, B, obsdim = obsdim)
+                @test kernelmatrix!(K[obsdim], newk, A, obsdim = obsdim) ≈ kernelmatrix(k, A, obsdim = obsdim)
+                @test kerneldiagmatrix!(Kdiag[obsdim], newk, A, obsdim = obsdim) ≈ kerneldiagmatrix(k, A, obsdim = obsdim)
             end
         end
         @testset "Transformed Kernel Matrix Operations" begin

--- a/test/matrix/kernelmatrix.jl
+++ b/test/matrix/kernelmatrix.jl
@@ -15,12 +15,12 @@
     @testset "Kernel Matrix Operations" begin
         @testset "Inplace Kernel Matrix" begin
             for obsdim in [1,2]
-                @test kernelmatrix!(K[obsdim],k,A,B,obsdim=obsdim) == kernelmatrix(k,A,B,obsdim=obsdim)
-                @test kernelmatrix!(K[obsdim],k,A,obsdim=obsdim) == kernelmatrix(k,A,obsdim=obsdim)
-                @test kerneldiagmatrix!(Kdiag[obsdim],k,A,obsdim=obsdim) == kerneldiagmatrix(k,A,obsdim=obsdim)
-                @test_throws DimensionMismatch kernelmatrix!(K[obsdim],k,A,C,obsdim=obsdim)
-                @test_throws DimensionMismatch kernelmatrix!(K[obsdim],k,C,obsdim=obsdim)
-                @test_throws DimensionMismatch kerneldiagmatrix!(Kdiag[obsdim],k,C,obsdim=obsdim)
+                @test kernelmatrix!(K[obsdim], k, A, B, obsdim = obsdim) == kernelmatrix(k, A, B, obsdim = obsdim)
+                @test kernelmatrix!(K[obsdim], k, A, obsdim = obsdim) == kernelmatrix(k, A, obsdim = obsdim)
+                @test kerneldiagmatrix!(Kdiag[obsdim], k, A, obsdim = obsdim) == kerneldiagmatrix(k, A, obsdim = obsdim)
+                @test_throws DimensionMismatch kernelmatrix!(K[obsdim], k, A, C, obsdim=obsdim)
+                @test_throws DimensionMismatch kernelmatrix!(K[obsdim], k, C, obsdim=obsdim)
+                @test_throws DimensionMismatch kerneldiagmatrix!(Kdiag[obsdim], k, C, obsdim=obsdim)
             end
         end
         @testset "Kernel matrix" begin

--- a/test/matrix/kernelmatrix.jl
+++ b/test/matrix/kernelmatrix.jl
@@ -1,3 +1,8 @@
+### Needs to be kept out for julia 1.0
+
+struct baseSE <: KernelFunctions.BaseKernel end
+(k::baseSE)(x, y) = exp(-evaluate(SqEuclidean(), x, y))
+
 @testset "kernelmatrix" begin
 
     rng = MersenneTwister(123456)
@@ -17,8 +22,6 @@
     Kdiag = [zeros(dims[1]),zeros(dims[2])]
     s = rand(rng)
     k = SqExponentialKernel()
-    struct baseSE <: KernelFunctions.BaseKernel end
-    (k::baseSE)(x, y) = exp(-evaluate(SqEuclidean(), x, y))
     newk = baseSE()
     kt = transform(SqExponentialKernel(),s)
 
@@ -29,7 +32,6 @@
             @test kernelmatrix!(K[2], k, vA) ≈ kernelmatrix(k, A) atol = 1e-5
             @test kernelmatrix!(K[2], k, vA, vB) ≈ kernelmatrix(k, A, B) atol = 1e-5
             for obsdim in [1,2]
-                @show obsdim
                 @test kernelmatrix!(K[obsdim], k, A, B, obsdim = obsdim) == kernelmatrix(k, A, B, obsdim = obsdim)
                 @test kernelmatrix!(K[obsdim], k, A, obsdim = obsdim) == kernelmatrix(k, A, obsdim = obsdim)
                 @test kerneldiagmatrix!(Kdiag[obsdim], k, A, obsdim = obsdim) == kerneldiagmatrix(k, A, obsdim = obsdim)
@@ -54,9 +56,9 @@
                 @test k(A,obsdim=obsdim) == kernelmatrix(k,A,obsdim=obsdim)
                 # @test KernelFunctions._kernel(k,1.0,2.0) == KernelFunctions._kernel(k,[1.0],[2.0])
                 @test_throws DimensionMismatch kernelmatrix(k,A,C,obsdim=obsdim)
-                @test kernelmatrix!(K[obsdim], newk, A, B, obsdim = obsdim) ≈ kernelmatrix(k, A, B, obsdim = obsdim)
-                @test kernelmatrix!(K[obsdim], newk, A, obsdim = obsdim) ≈ kernelmatrix(k, A, obsdim = obsdim)
-                @test kerneldiagmatrix!(Kdiag[obsdim], newk, A, obsdim = obsdim) ≈ kerneldiagmatrix(k, A, obsdim = obsdim)
+                @test kernelmatrix(newk, A, B, obsdim = obsdim) ≈ kernelmatrix(k, A, B, obsdim = obsdim)
+                @test kernelmatrix(newk, A, obsdim = obsdim) ≈ kernelmatrix(k, A, obsdim = obsdim)
+                @test kerneldiagmatrix(newk, A, obsdim = obsdim) ≈ kerneldiagmatrix(k, A, obsdim = obsdim)
             end
         end
         @testset "Transformed Kernel Matrix Operations" begin


### PR DESCRIPTION
I  added the notion of `SimpleKernel` for when `Distances.jl` pairwise can just be used.
While `BaseKernel` will just rely on `kappa(k, x, y)`
@willtebbutt Now I can see the point of `ColVecs`, is that okay if I steal your implementation from Stheno and rework it for our purpose?

[EDIT] This PR only aims at making the difference between `SimpleKernel` where `kernelmatrix` is based on `pairwise` from `Distances.jl`, `BaseKernel` where `kernelmatrix` relies on `kappa(k, x, y)` and `Kernel` which also contains composite kernels.
`ColVecs` and `RowVecs` are added separately in #84 and #89 