### PR TITLE
Simplify implementation of `TensorProduct`

### DIFF
--- a/src/kernels/kernelproduct.jl
+++ b/src/kernels/kernelproduct.jl
@@ -24,8 +24,6 @@ Base.length(k::KernelProduct) = length(k.kernels)
 
 (κ::KernelProduct)(x, y) = prod(k(x, y) for k in κ.kernels)
 
-hadamard(x, y) = x .* y
-
 function kernelmatrix(κ::KernelProduct, x::AbstractVector)
     return reduce(hadamard, kernelmatrix(κ.kernels[i], x) for i in 1:length(κ))
 end

--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -26,9 +26,6 @@ function (kernel::TensorProduct)(x, y)
     return prod(k(xi, yi) for (k, xi, yi) in zip(kernel.kernels, x, y))
 end
 
-# TODO: General implementation of `kernelmatrix` and `kerneldiagmatrix`
-# Default implementation assumes 1D observations
-
 function validate_domain(k::TensorProduct, x::AbstractVector)
     dim(x) == length(k) ||
         error("number of kernels and groups of features are not consistent")
@@ -70,25 +67,6 @@ function kernelmatrix!(
     return K
 end
 
-# mapreduce with multiple iterators requires Julia 1.2 or later.
-
-function kernelmatrix(k::TensorProduct, x::AbstractVector)
-    validate_domain(k, x)
-
-    return mapreduce((x, y) -> x .* y, zip(k.kernels, slices(x))) do (k, xi)
-        kernelmatrix(k, xi)
-    end
-end
-
-function kernelmatrix(k::TensorProduct, x::AbstractVector, y::AbstractVector)
-    validate_domain(k, x)
-
-    kernels_and_inputs = zip(k.kernels, slices(x), slices(y))
-    return mapreduce((x, y) -> x .* y, kernels_and_inputs) do (k, xi, yi)
-        kernelmatrix(k, xi, yi)
-    end
-end
-
 function kerneldiagmatrix!(K::AbstractVector, k::TensorProduct, x::AbstractVector)
     validate_inplace_dims(K, x)
     validate_domain(k, x)
@@ -102,13 +80,22 @@ function kerneldiagmatrix!(K::AbstractVector, k::TensorProduct, x::AbstractVecto
     return K
 end
 
+function kernelmatrix(k::TensorProduct, x::AbstractVector)
+    validate_domain(k, x)
+
+    return mapreduce(kernelmatrix, hadamard, k.kernels, slices(x))
+end
+
+function kernelmatrix(k::TensorProduct, x::AbstractVector, y::AbstractVector)
+    validate_domain(k, x)
+
+    return mapreduce(kernelmatrix, hadamard, k.kernels, slices(x), slices(y))
+end
+
 function kerneldiagmatrix(k::TensorProduct, x::AbstractVector)
     validate_domain(k, x)
 
-    kernels_and_inputs = zip(k.kernels, slices(x))
-    return mapreduce((x, y) -> x .* y, kernels_and_inputs) do (k, xi)
-        kerneldiagmatrix(k, xi)
-    end
+    return mapreduce(kerneldiagmatrix, hadamard, k.kernels, slices(x))
 end
 
 Base.show(io::IO, kernel::TensorProduct) = printshifted(io, kernel, 0)

--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -82,19 +82,16 @@ end
 
 function kernelmatrix(k::TensorProduct, x::AbstractVector)
     validate_domain(k, x)
-
     return mapreduce(kernelmatrix, hadamard, k.kernels, slices(x))
 end
 
 function kernelmatrix(k::TensorProduct, x::AbstractVector, y::AbstractVector)
     validate_domain(k, x)
-
     return mapreduce(kernelmatrix, hadamard, k.kernels, slices(x), slices(y))
 end
 
 function kerneldiagmatrix(k::TensorProduct, x::AbstractVector)
     validate_domain(k, x)
-
     return mapreduce(kerneldiagmatrix, hadamard, k.kernels, slices(x))
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,5 @@
+hadamard(x, y) = x .* y
+
 # Macro for checking arguments
 macro check_args(K, param, cond, desc=string(cond))
     quote


### PR DESCRIPTION
Simplifies the implementation of TensorProduct (possible now since we dropped support for Julia < 1.3).