### PR TITLE
Optimization of ScaleTransform for SimpleKernel

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -5,11 +5,6 @@ Base.iterate(k::Kernel, ::Any) = nothing
 
 printshifted(io::IO, o, shift::Int) = print(io, o)
 
-# See https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/issues/96
-_scale(t::ScaleTransform, metric::Euclidean, x, y) =  first(t.s) * evaluate(metric, x, y)
-_scale(t::ScaleTransform, metric::Union{SqEuclidean,DotProduct}, x, y) =  first(t.s)^2 * evaluate(metric, x, y)
-_scale(t::ScaleTransform, metric, x, y) = evaluate(metric, apply(t, x), apply(t, y))
-
 ### Syntactic sugar for creating matrices and using kernel functions
 function concretetypes(k, ktypes::Vector)
     isempty(subtypes(k)) ? push!(ktypes, k) : concretetypes.(subtypes(k), Ref(ktypes))

--- a/src/kernels/transformedkernel.jl
+++ b/src/kernels/transformedkernel.jl
@@ -10,6 +10,19 @@ struct TransformedKernel{Tk<:Kernel,Tr<:Transform} <: Kernel
 end
 
 (k::TransformedKernel)(x, y) = k.kernel(k.transform(x), k.transform(y))
+function (k::TransformedKernel{<:SimpleKernel,<:ScaleTransform})(x, y)
+    return kappa(k.kernel, _scale(k.transform, metric(k.kernel), x, y))
+end
+
+function _scale(t::ScaleTransform, metric::Euclidean, x, y)
+    return first(t.s) * evaluate(metric, x, y)
+end
+function _scale(t::ScaleTransform, metric::Union{SqEuclidean,DotProduct}, x, y)
+    return first(t.s)^2 * evaluate(metric, x, y)
+end
+function _scale(t::ScaleTransform, metric, x, y)
+    evaluate(metric, apply(t, x), apply(t, y))
+end
 
 """
 ```julia

--- a/src/kernels/transformedkernel.jl
+++ b/src/kernels/transformedkernel.jl
@@ -21,7 +21,7 @@ function _scale(t::ScaleTransform, metric::Union{SqEuclidean,DotProduct}, x, y)
     return first(t.s)^2 * evaluate(metric, x, y)
 end
 function _scale(t::ScaleTransform, metric, x, y)
-    evaluate(metric, apply(t, x), apply(t, y))
+    evaluate(metric, t(x), t(y))
 end
 
 """

--- a/src/kernels/transformedkernel.jl
+++ b/src/kernels/transformedkernel.jl
@@ -16,7 +16,7 @@ end
 # we perform a scalar multiplcation of the distance of the original inputs, if possible.
 function (k::TransformedKernel{<:SimpleKernel,<:ScaleTransform})(
     x::AbstractVector{<:Real},
-    y::AbstractVector{<:Real}
+    y::AbstractVector{<:Real},
 )
     return kappa(k.kernel, _scale(k.transform, metric(k.kernel), x, y))
 end

--- a/src/kernels/transformedkernel.jl
+++ b/src/kernels/transformedkernel.jl
@@ -10,7 +10,14 @@ struct TransformedKernel{Tk<:Kernel,Tr<:Transform} <: Kernel
 end
 
 (k::TransformedKernel)(x, y) = k.kernel(k.transform(x), k.transform(y))
-function (k::TransformedKernel{<:SimpleKernel,<:ScaleTransform})(x, y)
+
+# Optimizations for scale transforms of simple kernels to save allocations:
+# Instead of a multiplying every element of the inputs before evaluating the metric,
+# we perform a scalar multiplcation of the distance of the original inputs, if possible.
+function (k::TransformedKernel{<:SimpleKernel,<:ScaleTransform})(
+    x::AbstractVector{<:Real},
+    y::AbstractVector{<:Real}
+)
     return kappa(k.kernel, _scale(k.transform, metric(k.kernel), x, y))
 end
 
@@ -20,9 +27,7 @@ end
 function _scale(t::ScaleTransform, metric::Union{SqEuclidean,DotProduct}, x, y)
     return first(t.s)^2 * evaluate(metric, x, y)
 end
-function _scale(t::ScaleTransform, metric, x, y)
-    evaluate(metric, t(x), t(y))
-end
+_scale(t::ScaleTransform, metric, x, y) = evaluate(metric, t(x), t(y))
 
 """
 ```julia


### PR DESCRIPTION
Fixes https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/issues/96 by adapting the old code to the new interface. I'm not sure, maybe there's a better way to achieve this optimization?