### PR TITLE
Rewrite Zygote tests without broadcasting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ Requires = "1.0.1"
 SpecialFunctions = "0.8, 0.9, 0.10"
 StatsBase = "0.32, 0.33"
 StatsFuns = "0.8, 0.9"
-Zygote = "= 0.4.16"
 ZygoteRules = "0.2"
 julia = "1.3"
 

--- a/test/trainable.jl
+++ b/test/trainable.jl
@@ -1,56 +1,63 @@
 @testset "trainable" begin
-    using Flux: params
     ν = 2.0; c = 3.0; d = 2.0; γ = 2.0; α = 2.5; h = 0.5; r = rand(3)
 
+    function test_params(kernel, reference)
+        params_kernel = params(kernel)
+        params_reference = params(reference)
+
+        @test length(params_kernel) == length(params_reference)
+        @test all(p == q for (p, q) in zip(params_kernel, params_reference))
+    end
+
     kc = ConstantKernel(c=c)
-    @test all(params(kc) .== params([c]))
+    test_params(kc, ([c],))
 
     kfbm = FBMKernel(h = h)
-    @test all(params(kfbm) .== params([h]))
+    test_params(kfbm, ([h],))
 
     kge = GammaExponentialKernel(γ=γ)
-    @test all(params(kge) .== params([γ]))
+    test_params(kge, ([γ],))
 
     kgr = GammaRationalQuadraticKernel(γ=γ, α=α)
-    @test all(params(kgr) .== params([α], [γ]))
+    test_params(kgr, ([α], [γ]))
 
     kl = LinearKernel(c=c)
-    @test all(params(kl) .== params([c]))
+    test_params(kl, ([c],))
 
     km = MaternKernel(ν=ν)
-    @test all(params(km) .== params([ν]))
+    test_params(km, ([ν],))
 
     kp = PolynomialKernel(c=c, d=d)
-    @test all(params(kp) .== params([d], [c]))
+    test_params(kp, ([d], [c]))
 
     kpe = PeriodicKernel(r = r)
-    @test all(params(kpe) .== params(r))
+    test_params(kpe, (r,))
 
     kr = RationalQuadraticKernel(α=α)
-    @test all(params(kr) .== params([α]))
+    test_params(kr, ([α],))
 
     k = km + kc
-    @test all(params(k) .== params([k.weights], km, kc))
+    test_params(k, (k.weights, km, kc))
 
     k = km * kc
-    @test all(params(k) .== params(km, kc))
+    test_params(k, (km, kc))
 
     s = 2.0
     k = transform(km, s)
-    @test all(params(k) .== params([s], km))
+    test_params(k, ([s], km))
 
     v = [2.0]
     k = transform(kc, v)
-    @test all(params(k) .== params(v, kc))
+    test_params(k, (v, kc))
 
     P = rand(3, 2)
     k = transform(km, LinearTransform(P))
-    @test all(params(k) .== params(P, km))
+    test_params(k, (P, km))
 
     k = transform(km, LinearTransform(P) ∘ ScaleTransform(s))
-    @test all(params(k) .== params([s], P, km))
+    test_params(k, ([s], P, km))
 
     c = Chain(Dense(3, 2))
     k = transform(km, FunctionTransform(c))
-    @test all(params(k) .== params(c, km))
+    test_params(k, (c, km))
 end


### PR DESCRIPTION
This is an alternative to https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/pull/108 that should work with all (more or less) recent versions of Zygote since it does not depend on broadcasting. Note that the broadcasting fix in Zygote is not released yet, so broadcasting-based tests still fail with Zygote >= 0.4.17.