### PR TITLE
Length check before applying TensorProduct

### DIFF
--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -23,6 +23,8 @@ end
 Base.length(kernel::TensorProduct) = length(kernel.kernels)
 
 function (kernel::TensorProduct)(x, y)
+    @assert length(x) == length(kernel) && length(x) == length(kernel) "number
+of kernels and number of features are not consistent"
     return prod(k(xi, yi) for (k, xi, yi) in zip(kernel.kernels, x, y))
 end
 

--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -23,8 +23,10 @@ end
 Base.length(kernel::TensorProduct) = length(kernel.kernels)
 
 function (kernel::TensorProduct)(x, y)
-    @assert length(x) == length(kernel) && length(x) == length(kernel) "number
-of kernels and number of features are not consistent"
+    if !(length(x) == length(y) == length(kernel))
+        throw(DimensionMismatch("number of kernels and number of features
+are not consistent"))
+    end
     return prod(k(xi, yi) for (k, xi, yi) in zip(kernel.kernels, x, y))
 end
 

--- a/test/kernels/tensorproduct.jl
+++ b/test/kernels/tensorproduct.jl
@@ -13,7 +13,7 @@
 
     @test kernel1.kernels === (k1, k2) === TensorProduct((k1, k2)).kernels
     @test length(kernel1) == length(kernel2) == 2
-    @test_throws AssertionError kernel1(rand(3), rand(3))
+    @test_throws DimensionMismatch kernel1(rand(3), rand(3))
 
     @testset "val" begin
         for (x, y) in (((v1, u1), (v2, u2)), ([v1, u1], [v2, u2]))

--- a/test/kernels/tensorproduct.jl
+++ b/test/kernels/tensorproduct.jl
@@ -13,6 +13,7 @@
 
     @test kernel1.kernels === (k1, k2) === TensorProduct((k1, k2)).kernels
     @test length(kernel1) == length(kernel2) == 2
+    @test_throws AssertionError kernel1(rand(3), rand(3))
 
     @testset "val" begin
         for (x, y) in (((v1, u1), (v2, u2)), ([v1, u1], [v2, u2]))


### PR DESCRIPTION
As discussed with @willtebbutt earlier, `TensorProduct` doesn't check the dimension of the input before applying. This can lead to bugs which are hard to trace.

Currently:
```julia
julia> k = TensorProduct(ConstantKernel(c=2.0), ConstantKernel(c=2.0))
Tensor product of 2 kernels:
	- Constant Kernel (c = 2.0)
	- Constant Kernel (c = 2.0)

julia> k(rand(3), rand(3))
4.0
```  
It picks up the first `length(k)` dimensions of the input, ignoring the rest.