### PR TITLE
[WIP]Add a generic way to check kernel's input dimensions compatibility.

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -5,6 +5,8 @@ Base.iterate(k::Kernel, ::Any) = nothing
 
 printshifted(io::IO, o, shift::Int) = print(io, o)
 
+dims_are_compatible(::Kernel, x) = true
+
 ### Syntactic sugar for creating matrices and using kernel functions
 function concretetypes(k, ktypes::Vector)
     isempty(subtypes(k)) ? push!(ktypes, k) : concretetypes.(subtypes(k), Ref(ktypes))

--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -25,7 +25,7 @@ Base.length(kernel::TensorProduct) = length(kernel.kernels)
 dims_are_compatible(k::TensorProduct, x) = length(k) == length(x)
 
 function (kernel::TensorProduct)(x, y)
-    validate_kernel_dims(kernel, x)
+    validate_kernel_dims(kernel, x, y)
     return prod(k(xi, yi) for (k, xi, yi) in zip(kernel.kernels, x, y))
 end
 

--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -26,7 +26,6 @@ dims_are_compatible(k::TensorProduct, x) = length(k) == length(x)
 
 function (kernel::TensorProduct)(x, y)
     validate_kernel_dims(kernel, x)
-
     return prod(k(xi, yi) for (k, xi, yi) in zip(kernel.kernels, x, y))
 end
 

--- a/src/kernels/tensorproduct.jl
+++ b/src/kernels/tensorproduct.jl
@@ -22,11 +22,11 @@ end
 
 Base.length(kernel::TensorProduct) = length(kernel.kernels)
 
+dims_are_compatible(k::TensorProduct, x) = length(k) == length(x)
+
 function (kernel::TensorProduct)(x, y)
-    if !(length(x) == length(y) == length(kernel))
-        throw(DimensionMismatch("number of kernels and number of features
-are not consistent"))
-    end
+    validate_kernel_dims(kernel, x)
+
     return prod(k(xi, yi) for (k, xi, yi) in zip(kernel.kernels, x, y))
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -117,11 +117,27 @@ function validate_inplace_dims(K::AbstractVector, x::AbstractVector)
     end
 end
 
-function validate_dims(x::AbstractVector, y::AbstractVector)
+function validate_dims(x, y)
     if dim(x) != dim(y)
         throw(DimensionMismatch(
             "Dimensionality of x ($(dim(x))) not equality to that of y ($(dim(y)))",
         ))
+    end
+end
+
+function validate_kernel_dims(k::Kernel, x)
+    if !dims_are_compatible(k, x)
+        throw(DimensionMismatch(
+            "Dimensionality of kernel not compatible with that of input")
+              )
+    end
+end
+
+function validate_kernel_dims(k::Kernel, x, y)
+    if !(dims_are_compatible(k, x) && dims_are_compatible(k, y))
+        throw(DimensionMismatch(
+            "Dimensionality of kernel not compatible with that of input")
+              )
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -134,6 +134,7 @@ function validate_kernel_dims(k::Kernel, x)
 end
 
 function validate_kernel_dims(k::Kernel, x, y)
+    validate_dims(x, y)
     if !(dims_are_compatible(k, x) && dims_are_compatible(k, y))
         throw(DimensionMismatch(
             "Dimensionality of kernel not compatible with that of input")


### PR DESCRIPTION
Related PR #111 

Please find a generic way to deal with dimensions of inputs to kernels as @willtebbutt and @devmotion had suggested in #111 .

I had to remove restrictions on input type for `validate_dims` to accommodate few test cases for `TensorProduct`. 

If this setup is okay, I will proceed to apply similar checks to all kernels.