### PR TITLE
Some fixes for MaternKernel

### DIFF
--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -34,7 +34,7 @@ export spectral_mixture_kernel, spectral_mixture_product_kernel
 using Compat
 using Requires
 using Distances, LinearAlgebra
-using SpecialFunctions: logabsgamma, besselk, polygamma
+using SpecialFunctions: loggamma, besselk, polygamma
 using ZygoteRules: @adjoint, pullback
 using StatsFuns: logtwo
 using InteractiveUtils: subtypes

--- a/src/basekernels/matern.jl
+++ b/src/basekernels/matern.jl
@@ -21,7 +21,8 @@ end
 end
 
 function _matern(ν::Real, d::Real)
-    exp((one(d) - ν) * logtwo - loggamma(ν) + ν * log(sqrt(2ν) * d) + log(besselk(ν, sqrt(2ν) * d)))
+    y = sqrt(2ν) * d
+    return exp((one(d) - ν) * logtwo - loggamma(ν) + ν * log(y) + log(besselk(ν, y)))
 end
 
 metric(::MaternKernel) = Euclidean()

--- a/src/basekernels/matern.jl
+++ b/src/basekernels/matern.jl
@@ -16,8 +16,8 @@ struct MaternKernel{Tν<:Real} <: SimpleKernel
 end
 
 @inline function kappa(κ::MaternKernel, d::Real)
-    ν = first(κ.ν)
-    return ifelse(iszero(d), one(d), _matern(ν, d))
+    result = _matern(first(κ.ν), d)
+    return ifelse(iszero(d), one(result), result)
 end
 
 function _matern(ν::Real, d::Real)

--- a/src/basekernels/matern.jl
+++ b/src/basekernels/matern.jl
@@ -17,7 +17,7 @@ end
 
 @inline function kappa(κ::MaternKernel, d::Real)
     ν = first(κ.ν)
-    iszero(d) ? one(d) : _matern(ν, d)
+    return ifelse(iszero(d), one(d), _matern(ν, d))
 end
 
 function _matern(ν::Real, d::Real)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,5 @@
 hadamard(x, y) = x .* y
 
-loggamma(x) = first(logabsgamma(x))
-
 # Macro for checking arguments
 macro check_args(K, param, cond, desc=string(cond))
     quote

--- a/src/zygote_adjoints.jl
+++ b/src/zygote_adjoints.jl
@@ -59,10 +59,6 @@ end
   end
 end
 
-@adjoint function loggamma(x)
-    first(logabsgamma(x)) , Δ -> (Δ .* polygamma(0, x), )
-end
-
 @adjoint function kappa(κ::MaternKernel, d::Real)
     ν = first(κ.ν)
     val, grad = pullback(_matern, ν, d)

--- a/src/zygote_adjoints.jl
+++ b/src/zygote_adjoints.jl
@@ -59,16 +59,6 @@ end
   end
 end
 
-@adjoint function kappa(κ::MaternKernel, d::Real)
-    ν = first(κ.ν)
-    val, grad = pullback(_matern, ν, d)
-    return ((iszero(d) ? one(d) : val),
-    Δ -> begin
-        ∇ = grad(Δ)
-        return ((ν = [∇[1]],), iszero(d) ? zero(d) : ∇[2])
-    end)
-end
-
 @adjoint function ColVecs(X::AbstractMatrix)
     back(Δ::NamedTuple) = (Δ.X,)
     back(Δ::AbstractMatrix) = (Δ,)


### PR DESCRIPTION
This PR removes the `loggamma` definition and adjoint, removes the custom adjoint for `kappa(::MaternKernel, ::Real)`, and fixes a type instability of this function. The `loggamma` function is already defined in SpecialFunctions and the custom adjoint is not needed when one uses `ifelse` instead of `_ ? _ : _`, as suggested in https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/pull/114#discussion_r439545200:
```julia
julia> using Zygote

julia> Zygote.gradient(0.0) do x
        iszero(x) ? one(x) : x^2
       end
(nothing,)

julia> Zygote.gradient(1.0) do x
        iszero(x) ? one(x) : x^2
       end
(2.0,)

julia> Zygote.gradient(0.0) do x
        ifelse(iszero(x), one(x), x^2)
       end
(0.0,)

julia> Zygote.gradient(1.0) do x
        ifelse(iszero(x), one(x), x^2)
       end
(2.0,)
```

Moreover, the PR fixes a type instability of `kappa(::MaternKernel, ::Real)`. Currently
```julia
julia> @code_warntype KernelFunctions.kappa(MaternKernel(ν = 3.0), 1)
Variables
  #self#::Core.Compiler.Const(KernelFunctions.kappa, false)
  κ::MaternKernel{Float64}
  d::Int64
  ν::Float64

Body::Union{Float64, Int64}
1 ─      nothing
│   %2 = Base.getproperty(κ, :ν)::Array{Float64,1}
│        (ν = KernelFunctions.first(%2))
│   %4 = KernelFunctions.iszero(d)::Bool
│   %5 = KernelFunctions.one(d)::Core.Compiler.Const(1, false)
│   %6 = KernelFunctions._matern(ν, d)::Float64
│   %7 = KernelFunctions.ifelse(%4, %5, %6)::Union{Float64, Int64}
└──      return %7
```
whereas with this PR
```julia
julia> @code_warntype KernelFunctions.kappa(MaternKernel(ν = 3.0), 1)
Variables
  #self#::Core.Compiler.Const(KernelFunctions.kappa, false)
  κ::MaternKernel{Float64}
  d::Int64
  result::Float64

Body::Float64
1 ─      nothing
│   %2 = Base.getproperty(κ, :ν)::Array{Float64,1}
│   %3 = KernelFunctions.first(%2)::Float64
│        (result = KernelFunctions._matern(%3, d))
│   %5 = KernelFunctions.iszero(d)::Bool
│   %6 = KernelFunctions.one(result)::Core.Compiler.Const(1.0, false)
│   %7 = KernelFunctions.ifelse(%5, %6, result)::Float64
└──      return %7
```