### PR TITLE
Apply Transform on vector of vectors

### DIFF
--- a/src/transform/transform.jl
+++ b/src/transform/transform.jl
@@ -7,6 +7,7 @@ include("chaintransform.jl")
 
 
 Base.map(t::Transform, x::AbstractVector) = _map(t, x)
+_map(t::Transform, x::AbstractVector) = t.(x)
 
 """
     IdentityTransform()

--- a/test/transform/ardtransform.jl
+++ b/test/transform/ardtransform.jl
@@ -17,10 +17,11 @@
         v = randn(rng, D)
         t = ARDTransform(v)
 
+        XV = [randn(rng, D) for _ in 1:5]
         XC = ColVecs(randn(rng, D, 7))
         XR = RowVecs(randn(rng, 2, D))
 
-        @testset "$(typeof(x))" for x in [XC, XR]
+        @testset "$(typeof(x))" for x in [XV, XC, XR]
             x′ = map(t, x)
             @test all([t(x[n]) == v .* x[n] for n in eachindex(x)])
             @test all([t(x[n]) ≈ x′[n] for n in eachindex(x)])

--- a/test/transform/functiontransform.jl
+++ b/test/transform/functiontransform.jl
@@ -15,10 +15,11 @@
         f = x -> sin.(x)
         t = FunctionTransform(f)
 
+        x_vecs = [randn(rng, 5) for _ in 1:6]
         x_cols = ColVecs(randn(rng, 4, 7))
         x_rows = RowVecs(randn(rng, 6, 3))
 
-        @testset "$(typeof(x))" for x in [x_cols, x_rows]
+        @testset "$(typeof(x))" for x in [x_vecs, x_cols, x_rows]
             x′ = map(t, x)
             @test all([t(x[n]) ≈ f(x[n]) for n in eachindex(x)])
             @test all([t(x[n]) ≈ x′[n] for n in eachindex(x)])

--- a/test/transform/lineartransform.jl
+++ b/test/transform/lineartransform.jl
@@ -18,10 +18,11 @@
         P = randn(rng, Dout, Din)
         t = LinearTransform(P)
 
+        x_vecs = [randn(rng, Din) for _ in 1:6]
         x_cols = ColVecs(randn(rng, Din, 8))
         x_rows = RowVecs(randn(rng, 9, Din))
 
-        @testset "$(typeof(x))" for x in [x_cols, x_rows]
+        @testset "$(typeof(x))" for x in [x_vecs, x_cols, x_rows]
             x′ = map(t, x)
             @test all([t(x[n]) ≈ P * x[n] for n in eachindex(x)])
             @test all([t(x[n]) ≈ x′[n] for n in eachindex(x)])

--- a/test/transform/scaletransform.jl
+++ b/test/transform/scaletransform.jl
@@ -4,10 +4,11 @@
     t = ScaleTransform(s)
 
     x = randn(rng, 7)
+    XV = [randn(rng, 6) for _ in 1:4]
     XC = ColVecs(randn(rng, 10, 5))
     XR = RowVecs(randn(rng, 6, 11))
 
-    @testset "$(typeof(x))" for x in [x, XC, XR]
+    @testset "$(typeof(x))" for x in [x, XV, XC, XR]
         x′ = map(t, x)
         @test all([t(x[n]) ≈ s .* x[n] for n in eachindex(x)])
         @test all([t(x[n]) ≈ x′[n] for n in eachindex(x)])

--- a/test/transform/selecttransform.jl
+++ b/test/transform/selecttransform.jl
@@ -4,10 +4,11 @@
     select = [1, 3, 5]
     t = SelectTransform(select)
 
+    x_vecs = [randn(rng, maximum(select)) for _ in 1:3]
     x_cols = ColVecs(randn(rng, maximum(select), 6))
     x_rows = RowVecs(randn(rng, 4, maximum(select)))
 
-    @testset "$(typeof(x))" for x in [x_cols, x_rows]
+    @testset "$(typeof(x))" for x in [x_vecs, x_cols, x_rows]
         x′ = map(t, x)
         @test all([t(x[n]) == x[n][select] for n in eachindex(x)])
         @test all([t(x[n]) == x′[n] for n in eachindex(x)])

--- a/test/transform/transform.jl
+++ b/test/transform/transform.jl
@@ -1,9 +1,10 @@
 @testset "transform" begin
     rng = MersenneTwister(123546)
     x = randn(rng, 8)
+    XV = [randn(rng, 5) for _ in 1:6]
     XC = ColVecs(randn(rng, 5, 10))
     XR = RowVecs(randn(rng, 11, 3))
-    @testset "IdentityTransform($(typeof(x)))" for x in [x, XC, XR]
+    @testset "IdentityTransform($(typeof(x)))" for x in [x, XV, XC, XR]
         @test IdentityTransform()(x) == x
         @test map(IdentityTransform(), x) == x
     end


### PR DESCRIPTION
Well it was not possible before... Now it is!
Now `map(t, x::AbstractVector)`  will return `t.(x)` (instead of returning an error