### PR TITLE
ENH: add ANOVA kernel

### DIFF
--- a/src/basekernels/anova.jl
+++ b/src/basekernels/anova.jl
@@ -1,0 +1,56 @@
+struct ANOVAKernel{T<:Real} <: BaseKernel
+    d::Vector{T}
+    function ANOVAKernel(; d::T=1.0) where {T<:Real}
+        @assert d > 0 "ANOVAKernel: Given degree d is invalid."
+        return new{T}([d])
+    end
+end
+
+function (κ::ANOVAKernel)(x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
+    return sum(exp.( - (x .- y).^2 ) .^ first(κ.d))
+end
+
+(κ::ANOVAKernel)(x::Real, y::Real) = exp( - (x - y)^2 )^first(κ.d)
+
+Base.show(io::IO, κ::ANOVAKernel) = print(io, "ANOVA Kernel d = ", first(κ.d), ")")
+
+function kernelmatrix(κ::ANOVAKernel, x::AbstractVector)
+    k = zeros(eltype(x), dim(x), dim(x))
+    for d ∈ size(x)
+        col = reshape(x[d], dim(x), 1)
+        k += exp( - (col .- col').^2 ) .^ first(κ.d)
+    end
+    return k
+end
+
+function kernelmatrix!(K::AbstractMatrix, κ::ANOVAKernel, x::AbstractVector)
+    for d ∈ size(x)
+        col = reshape(x[d], dim(x), 1)
+        K += exp( - (col .- col').^2 ) .^ first(κ.d)
+    end
+    return K
+end
+
+function kernelmatrix(κ::ANOVAKernel, x::AbstractVector, y::AbstractVector)
+    k = zeros(eltype(x), dim(x), dim(y))
+    for d ∈ size(x)
+        colx = reshape(x[d], dim(x), 1)
+        coly = reshape(y[d], dim(y), 1)
+        k += exp( - (colx .- coly').^2 ) .^ first(κ.d)
+    end
+    return k
+end
+
+function kernelmatrix!(
+    K::AbstractMatrix,
+    κ::ANOVAKernel,
+    x::AbstractVector,
+    y::AbstractVector,
+)
+    for d ∈ size(x)
+        colx = reshape(x[d], dim(x), 1)
+        coly = reshape(y[d], dim(y), 1)
+        K += exp( - (colx .- coly').^2 ) .^ first(κ.d)
+    end
+    return K
+end

--- a/src/basekernels/anova.jl
+++ b/src/basekernels/anova.jl
@@ -10,35 +10,43 @@ function (κ::ANOVAKernel)(x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
     return sum(exp.( - (x .- y).^2 ) .^ first(κ.d))
 end
 
-(κ::ANOVAKernel)(x::Real, y::Real) = exp( - (x - y)^2 )^first(κ.d)
+(κ::ANOVAKernel)(x::Real, y::Real) = exp( - (x - y)^2 ) ^ first(κ.d)
 
-Base.show(io::IO, κ::ANOVAKernel) = print(io, "ANOVA Kernel d = ", first(κ.d), ")")
+Base.show(io::IO, κ::ANOVAKernel) = print(io, "ANOVA Kernel (d = ", first(κ.d), ")")
 
-function kernelmatrix(κ::ANOVAKernel, x::AbstractVector)
-    k = zeros(eltype(x), dim(x), dim(x))
-    for d ∈ size(x)
-        col = reshape(x[d:d], dim(x), 1)
-        k += exp( - (col .- col').^2 ) .^ first(κ.d)
+_dist(κ::ANOVAKernel, x::AbstractVector{<:Real}, y::AbstractVector{<:Real}) = exp.( - (x .- x').^2 ) .^ first(κ.d)
+
+function _dist(κ::ANOVAKernel, x::ColVecs, y::ColVecs)
+    k = zeros(eltype(x), first(size(x)), first(size(y)))
+    for d ∈ dim(x)
+        colx = view(x.X, d, :)
+        coly = view(y.X, d, :)
+        k += exp.( - (colx .- coly').^2 ) .^ first(κ.d)
     end
     return k
 end
 
-function kernelmatrix!(K::AbstractMatrix, κ::ANOVAKernel, x::AbstractVector)
-    for d ∈ size(x)
-        col = reshape(x[d:d], dim(x), 1)
-        K += exp( - (col .- col').^2 ) .^ first(κ.d)
+function _dist(κ::ANOVAKernel, x::RowVecs, y::RowVecs)
+    k = zeros(eltype(x), first(size(x)), first(size(y)))
+    for d ∈ dim(x)
+        colx = view(x.X, :, d)
+        coly = view(y.X, :, d)
+        k += exp.( - (colx .- coly').^2 ) .^ first(κ.d)
     end
+    return k
+end
+
+function kernelmatrix(κ::ANOVAKernel, x::AbstractVector)
+    return _dist(κ, x, x)
+end
+
+function kernelmatrix!(K::AbstractMatrix, κ::ANOVAKernel, x::AbstractVector)
+    K .= _dist(κ, x, x)
     return K
 end
 
 function kernelmatrix(κ::ANOVAKernel, x::AbstractVector, y::AbstractVector)
-    k = zeros(eltype(x), dim(x), dim(y))
-    for d ∈ size(x)
-        colx = reshape(x[d:d], dim(x), 1)
-        coly = reshape(y[d:d], dim(y), 1)
-        k += exp( - (colx .- coly').^2 ) .^ first(κ.d)
-    end
-    return k
+    return _dist(κ, x, y)
 end
 
 function kernelmatrix!(
@@ -47,10 +55,6 @@ function kernelmatrix!(
     x::AbstractVector,
     y::AbstractVector,
 )
-    for d ∈ size(x)
-        colx = reshape(x[d:d], dim(x), 1)
-        coly = reshape(y[d:d], dim(y), 1)
-        K += exp( - (colx .- coly').^2 ) .^ first(κ.d)
-    end
+    K .= _dist(κ, x, y)
     return K
 end

--- a/src/basekernels/anova.jl
+++ b/src/basekernels/anova.jl
@@ -1,3 +1,11 @@
+"""
+    ANOVAKernel(; d::Real=1.0)
+
+The anova kernel is a stationary kernel given by
+```
+    κ(x,y) = ∑ᵢ exp( -(xᵢ - yᵢ)^2 )^d
+```
+"""
 struct ANOVAKernel{T<:Real} <: BaseKernel
     d::Vector{T}
     function ANOVAKernel(; d::T=1.0) where {T<:Real}

--- a/src/basekernels/anova.jl
+++ b/src/basekernels/anova.jl
@@ -17,7 +17,7 @@ Base.show(io::IO, κ::ANOVAKernel) = print(io, "ANOVA Kernel d = ", first(κ.d),
 function kernelmatrix(κ::ANOVAKernel, x::AbstractVector)
     k = zeros(eltype(x), dim(x), dim(x))
     for d ∈ size(x)
-        col = reshape(x[d], dim(x), 1)
+        col = reshape(x[d:d], dim(x), 1)
         k += exp( - (col .- col').^2 ) .^ first(κ.d)
     end
     return k
@@ -25,7 +25,7 @@ end
 
 function kernelmatrix!(K::AbstractMatrix, κ::ANOVAKernel, x::AbstractVector)
     for d ∈ size(x)
-        col = reshape(x[d], dim(x), 1)
+        col = reshape(x[d:d], dim(x), 1)
         K += exp( - (col .- col').^2 ) .^ first(κ.d)
     end
     return K
@@ -34,8 +34,8 @@ end
 function kernelmatrix(κ::ANOVAKernel, x::AbstractVector, y::AbstractVector)
     k = zeros(eltype(x), dim(x), dim(y))
     for d ∈ size(x)
-        colx = reshape(x[d], dim(x), 1)
-        coly = reshape(y[d], dim(y), 1)
+        colx = reshape(x[d:d], dim(x), 1)
+        coly = reshape(y[d:d], dim(y), 1)
         k += exp( - (colx .- coly').^2 ) .^ first(κ.d)
     end
     return k
@@ -48,8 +48,8 @@ function kernelmatrix!(
     y::AbstractVector,
 )
     for d ∈ size(x)
-        colx = reshape(x[d], dim(x), 1)
-        coly = reshape(y[d], dim(y), 1)
+        colx = reshape(x[d:d], dim(x), 1)
+        coly = reshape(y[d:d], dim(y), 1)
         K += exp( - (colx .- coly').^2 ) .^ first(κ.d)
     end
     return K

--- a/src/trainable.jl
+++ b/src/trainable.jl
@@ -24,6 +24,8 @@ trainable(k::MahalanobisKernel) = (k.P,)
 
 trainable(k::GaborKernel) = (k.kernel,)
 
+trainable(k::ANOVAKernel) = (k.d,)
+
 #### Composite kernels
 
 trainable(κ::KernelProduct) = κ.kernels

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -40,6 +40,7 @@ Base.size(D::ColVecs) = (size(D.X, 2),)
 Base.getindex(D::ColVecs, i::Int) = view(D.X, :, i)
 Base.getindex(D::ColVecs, i::CartesianIndex{1}) = view(D.X, :, i)
 Base.getindex(D::ColVecs, i) = ColVecs(view(D.X, :, i))
+Base.eltype(D::ColVecs) = eltype(D.X)
 
 dim(x::ColVecs) = size(x.X, 1)
 
@@ -70,6 +71,7 @@ Base.size(D::RowVecs) = (size(D.X, 1),)
 Base.getindex(D::RowVecs, i::Int) = view(D.X, i, :)
 Base.getindex(D::RowVecs, i::CartesianIndex{1}) = view(D.X, i, :)
 Base.getindex(D::RowVecs, i) = RowVecs(view(D.X, i, :))
+Base.eltype(D::RowVecs) = eltype(D.X)
 
 dim(x::RowVecs) = size(x.X, 2)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -41,7 +41,6 @@ Base.getindex(D::ColVecs, i::Int) = view(D.X, :, i)
 Base.getindex(D::ColVecs, i::CartesianIndex{1}) = view(D.X, :, i)
 Base.getindex(D::ColVecs, i) = ColVecs(view(D.X, :, i))
 Base.eltype(D::ColVecs) = eltype(D.X)
-Base.getindex(D::ColVecs, I::UnitRange{Int}) = view(D.X, :, I)
 
 dim(x::ColVecs) = size(x.X, 1)
 
@@ -73,7 +72,6 @@ Base.getindex(D::RowVecs, i::Int) = view(D.X, i, :)
 Base.getindex(D::RowVecs, i::CartesianIndex{1}) = view(D.X, i, :)
 Base.getindex(D::RowVecs, i) = RowVecs(view(D.X, i, :))
 Base.eltype(D::RowVecs) = eltype(D.X)
-Base.getindex(D::RowVecs, I::UnitRange{Int}) = view(D.X, I, :)
 
 dim(x::RowVecs) = size(x.X, 2)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -41,6 +41,7 @@ Base.getindex(D::ColVecs, i::Int) = view(D.X, :, i)
 Base.getindex(D::ColVecs, i::CartesianIndex{1}) = view(D.X, :, i)
 Base.getindex(D::ColVecs, i) = ColVecs(view(D.X, :, i))
 Base.eltype(D::ColVecs) = eltype(D.X)
+Base.getindex(D::ColVecs, I::UnitRange{Int}) = view(D.X, :, I)
 
 dim(x::ColVecs) = size(x.X, 1)
 
@@ -72,6 +73,7 @@ Base.getindex(D::RowVecs, i::Int) = view(D.X, i, :)
 Base.getindex(D::RowVecs, i::CartesianIndex{1}) = view(D.X, i, :)
 Base.getindex(D::RowVecs, i) = RowVecs(view(D.X, i, :))
 Base.eltype(D::RowVecs) = eltype(D.X)
+Base.getindex(D::RowVecs, I::UnitRange{Int}) = view(D.X, I, :)
 
 dim(x::RowVecs) = size(x.X, 2)
 

--- a/test/basekernels/anova.jl
+++ b/test/basekernels/anova.jl
@@ -1,0 +1,24 @@
+@testset "ANOVA" begin
+    rng = MersenneTwister(42)
+    d = 2.
+    k = ANOVAKernel(d = d)
+    v1 = rand(rng, 3); v2 = rand(rng, 3)
+    @test k(v1, v2) ≈ sum(exp.( - (v1 .- v2).^2 ) .^ 2)
+    @test k(1., 2.) ≈ exp(-1.)^2
+
+    # kernelmatrix tests
+    m1 = rand(rng, 3, 3)
+    m2 = rand(rng, 3, 3)
+    Kref = kernelmatrix(k, m1, m1)
+    @test kernelmatrix(k, m1) ≈ Kref atol=1e-5
+    K = zeros(3, 3)
+    kernelmatrix!(K, k, m1, m1)
+    @test K ≈ Kref atol=1e-5
+    fill!(K, 0)
+    kernelmatrix!(K, k, m1)
+    @test K ≈ Kref atol=1e-5
+
+    # repr test
+    @test repr(k) == "ANOVA Kernel (d = 2.0)"
+    test_ADs(ANOVAKernel)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,6 +82,7 @@ using KernelFunctions: metric, kappa, ColVecs, RowVecs
         include(joinpath("basekernels", "rationalquad.jl"))
         include(joinpath("basekernels", "sm.jl"))
         include(joinpath("basekernels", "wiener.jl"))
+        include(joinpath("basekernels", "anova.jl"))
     end
     @info "Ran tests on BaseKernel"
 


### PR DESCRIPTION
Fixes #67 

I have tried to add a ANOVA kernel but am worried about optimizations. [This paper section 9.2, algorithm 9.14](https://people.eecs.berkeley.edu/~jordan/kernels/0521813972c09_p291-326.pdf) uses a DP approach to efficiently evaluate the kernel matrix. I have implemented a naive recurring algorithm for computing the `kernelmatrix`.

Changes:
 - [x] Add ANOVA Kernel.
 - [x] Add `ANOVAKernel`'s test suite.
 - [x] Add docs