### PR TITLE
Tweak implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/distances/delta.jl
+++ b/src/distances/delta.jl
@@ -1,9 +1,12 @@
 struct Delta <: Distances.PreMetric
 end
 
-@inline function Distances._evaluate(::Delta, a::AbstractVector{Ta}, b::AbstractVector{Tb}) where {Ta, Tb}
+@inline function Distances._evaluate(::Delta, a::AbstractVector, b::AbstractVector)
     @boundscheck if length(a) != length(b)
-        throw(DimensionMismatch("first array has length $(length(a)) which does not match the length of the second, $(length(b))."))
+        throw(DimensionMismatch(
+            "first array has length $(length(a)) which does not match the length of the " *
+            "second, $(length(b)).",
+        ))
     end
     return a == b
 end

--- a/src/distances/delta.jl
+++ b/src/distances/delta.jl
@@ -5,7 +5,7 @@ end
     @boundscheck if length(a) != length(b)
         throw(DimensionMismatch("first array has length $(length(a)) which does not match the length of the second, $(length(b))."))
     end
-    return convert(promote_type(Ta, Tb), a == b)
+    return a == b
 end
 
 Distances.result_type(::Delta, Ta::Type, Tb::Type) = promote_type(Ta, Tb)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -14,7 +14,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Distances = "0.9"
-FiniteDifferences = "0.10"
+FiniteDifferences = "0.10.8"
 Flux = "0.10, 0.11"
 ForwardDiff = "0.10"
 Kronecker = "0.4"


### PR DESCRIPTION
This reverts the change to the `Delta` distance made in #138 as it's not quite right, and FiniteDifferences 0.10.8 fixes the issue that we had before.

Also bumps the version so that we can release a new patch version.