### PR TITLE
Fixing implicit gradients

### DIFF
--- a/src/kernels/transformedkernel.jl
+++ b/src/kernels/transformedkernel.jl
@@ -63,11 +63,11 @@ end
 # Kernel matrix operations
 
 function kerneldiagmatrix!(K::AbstractVector, κ::TransformedKernel, x::AbstractVector)
-    return kerneldiagmatrix!(K, κ.kernel, map(κ.transform, x))
+    return kerneldiagmatrix!(K, κ.kernel, _map(κ.transform, x))
 end
 
 function kernelmatrix!(K::AbstractMatrix, κ::TransformedKernel, x::AbstractVector)
-    return kernelmatrix!(K, kernel(κ), map(κ.transform, x))
+    return kernelmatrix!(K, kernel(κ), _map(κ.transform, x))
 end
 
 function kernelmatrix!(
@@ -76,17 +76,17 @@ function kernelmatrix!(
     x::AbstractVector,
     y::AbstractVector,
 )
-    return kernelmatrix!(K, kernel(κ), map(κ.transform, x), map(κ.transform, y))
+    return kernelmatrix!(K, kernel(κ), _map(κ.transform, x), _map(κ.transform, y))
 end
 
 function kerneldiagmatrix(κ::TransformedKernel, x::AbstractVector)
-    return kerneldiagmatrix(κ.kernel, map(κ.transform, x))
+    return kerneldiagmatrix(κ.kernel, _map(κ.transform, x))
 end
 
 function kernelmatrix(κ::TransformedKernel, x::AbstractVector)
-    return kernelmatrix(kernel(κ), map(κ.transform, x))
+    return kernelmatrix(kernel(κ), _map(κ.transform, x))
 end
 
 function kernelmatrix(κ::TransformedKernel, x::AbstractVector, y::AbstractVector)
-    return kernelmatrix(kernel(κ), map(κ.transform, x), map(κ.transform, y))
+    return kernelmatrix(kernel(κ), _map(κ.transform, x), _map(κ.transform, y))
 end

--- a/src/transform/scaletransform.jl
+++ b/src/transform/scaletransform.jl
@@ -19,9 +19,9 @@ set!(t::ScaleTransform,ρ::Real) = t.s .= [ρ]
 
 (t::ScaleTransform)(x) = first(t.s) * x
 
-_map(t::ScaleTransform, x::AbstractVector{<:Real}) = t(x)
-_map(t::ScaleTransform, x::ColVecs) = ColVecs(t(x.X))
-_map(t::ScaleTransform, x::RowVecs) = RowVecs(t(x.X))
+_map(t::ScaleTransform, x::AbstractVector{<:Real}) = first(t.s) .* x
+_map(t::ScaleTransform, x::ColVecs) = ColVecs(first(t.s) .* x.X)
+_map(t::ScaleTransform, x::RowVecs) = RowVecs(first(t.s) .* x.X)
 
 Base.isequal(t::ScaleTransform,t2::ScaleTransform) = isequal(first(t.s),first(t2.s))
 

--- a/src/transform/scaletransform.jl
+++ b/src/transform/scaletransform.jl
@@ -21,7 +21,7 @@ set!(t::ScaleTransform,ρ::Real) = t.s .= [ρ]
 
 _map(t::ScaleTransform, x::AbstractVector{<:Real}) = t(x)
 _map(t::ScaleTransform, x::ColVecs) = ColVecs(t(x.X))
-_map(t::ScaleTransform, x::RowVecs) = RowVecs(t(x.X)
+_map(t::ScaleTransform, x::RowVecs) = RowVecs(t(x.X))
 
 Base.isequal(t::ScaleTransform,t2::ScaleTransform) = isequal(first(t.s),first(t2.s))
 

--- a/src/transform/scaletransform.jl
+++ b/src/transform/scaletransform.jl
@@ -17,11 +17,11 @@ end
 
 set!(t::ScaleTransform,ρ::Real) = t.s .= [ρ]
 
-(t::ScaleTransform)(x) = first(t.s) .* x
+(t::ScaleTransform)(x) = first(t.s) * x
 
-_map(t::ScaleTransform, x::AbstractVector{<:Real}) = first(t.s) .* x
-_map(t::ScaleTransform, x::ColVecs) = ColVecs(first(t.s) .* x.X)
-_map(t::ScaleTransform, x::RowVecs) = RowVecs(first(t.s) .* x.X)
+_map(t::ScaleTransform, x::AbstractVector{<:Real}) = t(x)
+_map(t::ScaleTransform, x::ColVecs) = ColVecs(t(x.X))
+_map(t::ScaleTransform, x::RowVecs) = RowVecs(t(x.X)
 
 Base.isequal(t::ScaleTransform,t2::ScaleTransform) = isequal(first(t.s),first(t2.s))
 


### PR DESCRIPTION
Until now there was a major issue where implicit gradients on `TransformedKernel`, i.e. :
```
k = transform(SqExponentialKernel(), 2.0)
gradient(params(k) do 
 something...
end
```
would return nothing.
This fixes #137 by not using map to apply the transform operation and adds tests to check the behaviour