### PR TITLE
Fix Independent MOKernel for single dimension input

### DIFF
--- a/src/mokernels/independent.jl
+++ b/src/mokernels/independent.jl
@@ -7,9 +7,11 @@ struct IndependentMOKernel{Tkernel<:Kernel} <: Kernel
     kernel::Tkernel
 end
 
-function (κ::IndependentMOKernel)(x::Tuple{Vector, Int}, y::Tuple{Vector, Int})
-    if last(x) == last(y)
-        return κ.kernel(first(x), first(y))
+function (κ::IndependentMOKernel)((x, px)::Tuple{Real, Int}, (y, py)::Tuple{Real, Int}) = κ(([x], px), ([y], py))
+
+function (κ::IndependentMOKernel)((x, px)::Tuple{Vector, Int}, (y, py)::Tuple{Vector, Int})
+    if px == py
+        return κ.kernel(x, y)
     else
         return 0.0
     end

--- a/src/mokernels/independent.jl
+++ b/src/mokernels/independent.jl
@@ -7,7 +7,9 @@ struct IndependentMOKernel{Tkernel<:Kernel} <: Kernel
     kernel::Tkernel
 end
 
-function (κ::IndependentMOKernel)((x, px)::Tuple{Real, Int}, (y, py)::Tuple{Real, Int}) = κ(([x], px), ([y], py))
+function (κ::IndependentMOKernel)((x, px)::Tuple{Real, Int}, (y, py)::Tuple{Real, Int})
+    return κ(([x], px), ([y], py))
+end
 
 function (κ::IndependentMOKernel)((x, px)::Tuple{Vector, Int}, (y, py)::Tuple{Vector, Int})
     if px == py

--- a/test/mokernels/independent.jl
+++ b/test/mokernels/independent.jl
@@ -10,5 +10,10 @@
 
     @test kernelmatrix(k, x, y) == kernelmatrix(k, collect(x), collect(y))
     @test kernelmatrix(k, x, x) == kernelmatrix(k, x)
+
+    x1 = MOInput(rand(5), 3) # Single dim input
+    @test k(x1[1], x1[1]) isa Real
+    @test kernelmatrix(k, x1) isa Matrix
+
     @test string(k) == "Independent Multi-Output Kernel\n\tSquared Exponential Kernel"
 end

--- a/test/mokernels/independent.jl
+++ b/test/mokernels/independent.jl
@@ -12,8 +12,8 @@
     @test kernelmatrix(k, x, x) == kernelmatrix(k, x)
 
     x1 = MOInput(rand(5), 3) # Single dim input
-    @test_nothrow k(x1[1], x1[1])
-    @test_nothrow kernelmatrix(k, x1)
+    @test k(x1[1], x1[1]) isa Real
+    @test kernelmatrix(k, x1) isa Matrix
 
     @test string(k) == "Independent Multi-Output Kernel\n\tSquared Exponential Kernel"
 end

--- a/test/mokernels/independent.jl
+++ b/test/mokernels/independent.jl
@@ -12,8 +12,8 @@
     @test kernelmatrix(k, x, x) == kernelmatrix(k, x)
 
     x1 = MOInput(rand(5), 3) # Single dim input
-    @test k(x1[1], x1[1]) isa Real
-    @test kernelmatrix(k, x1) isa Matrix
+    @test_nothrow k(x1[1], x1[1])
+    @test_nothrow kernelmatrix(k, x1)
 
     @test string(k) == "Independent Multi-Output Kernel\n\tSquared Exponential Kernel"
 end


### PR DESCRIPTION
Fails for 
```julia
N = 100
x = rand(Uniform(-1, 1), N)
X = MOInput(x, 2)
k = IndependentMOKernel(MaternKernel())
k(X, X) #error
```