### PR TITLE
Test stable Julia version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,18 @@ os:
   - osx
 julia:
   - 1.3
-  - 1.4
+  - 1
   - nightly
 notifications:
   email: false
 after_success:
-  - if [[ $TRAVIS_JULIA_VERSION = 1.4 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
+  - if [[ $TRAVIS_JULIA_VERSION = 1 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
       julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())';
     fi
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.4
+      julia: 1
       os: linux
       script:
         - export DOCUMENTER_DEBUG=true


### PR DESCRIPTION
I guess it makes sense to not hardcode Julia 1.4 in our Travis CI setup but rather always test the minimum supported version, the stable version, and the latest Julia build (even more so since Julia 1.5 was just released).