### PR TITLE
Remove BaseKernel and deprecated functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -48,8 +48,7 @@ Abstract type defining a slice-wise transformation on an input matrix
 abstract type Transform end
 
 abstract type Kernel end
-abstract type BaseKernel <: Kernel end
-abstract type SimpleKernel <: BaseKernel end
+abstract type SimpleKernel <: Kernel end
 
 include("utils.jl")
 include("distances/pairwise.jl")

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -14,6 +14,7 @@ export CosineKernel
 export SqExponentialKernel, RBFKernel, GaussianKernel, SEKernel
 export LaplacianKernel, ExponentialKernel, GammaExponentialKernel
 export ExponentiatedKernel
+export FBMKernel
 export MaternKernel, Matern32Kernel, Matern52Kernel
 export LinearKernel, PolynomialKernel
 export RationalQuadraticKernel, GammaRationalQuadraticKernel

--- a/src/basekernels/fbm.jl
+++ b/src/basekernels/fbm.jl
@@ -9,7 +9,7 @@ Fractional Brownian motion kernel with Hurst index `h` from (0,1) given by
 For `h=1/2`, this is the Wiener Kernel, for `h>1/2`, the increments are
 positively correlated and for `h<1/2` the increments are negatively correlated.
 """
-struct FBMKernel{T<:Real} <: BaseKernel
+struct FBMKernel{T<:Real} <: Kernel
     h::Vector{T}
     function FBMKernel(; h::T=0.5) where {T<:Real}
         @assert 0.0 <= h <= 1.0 "FBMKernel: Given Hurst index h is invalid."

--- a/src/basekernels/gabor.jl
+++ b/src/basekernels/gabor.jl
@@ -7,7 +7,7 @@ Gabor kernel with lengthscale `ell` and period `p`. Given by
 ```
 
 """
-struct GaborKernel{K<:Kernel} <: BaseKernel
+struct GaborKernel{K<:Kernel} <: Kernel
     kernel::K
     function GaborKernel(;ell=nothing, p=nothing)
         k = _gabor(ell=ell, p=p)

--- a/src/basekernels/nn.jl
+++ b/src/basekernels/nn.jl
@@ -17,7 +17,7 @@ Bayesian neural network with erf (Error Function) as activation function.
 - [Neal(1996)](https://www.cs.toronto.edu/~radford/bnn.book.html)
 - [Andrew Gordon's Thesis Pg 45](http://www.cs.cmu.edu/~andrewgw/andrewgwthesis.pdf)
 """
-struct NeuralNetworkKernel <: BaseKernel end
+struct NeuralNetworkKernel <: Kernel end
 
 function (κ::NeuralNetworkKernel)(x, y)
     return asin(dot(x, y) / sqrt((1 + sum(abs2, x)) * (1 + sum(abs2, y))))

--- a/src/basekernels/wiener.jl
+++ b/src/basekernels/wiener.jl
@@ -32,7 +32,7 @@ See the paper *Probabilistic ODE Solvers with Runge-Kutta Means* by Schober, Duv
 Hennig, NIPS, 2014, for more details.
 
 """
-struct WienerKernel{I} <: BaseKernel
+struct WienerKernel{I} <: Kernel
     function WienerKernel{I}() where I
         @assert I ∈ (-1, 0, 1, 2, 3) "Invalid parameter i=$(I). Should be -1, 0, 1, 2 or 3."
         if I == -1

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -5,11 +5,5 @@ Base.iterate(k::Kernel, ::Any) = nothing
 
 printshifted(io::IO, o, shift::Int) = print(io, o)
 
-### Syntactic sugar for creating matrices and using kernel functions
-function concretetypes(k, ktypes::Vector)
-    isempty(subtypes(k)) ? push!(ktypes, k) : concretetypes.(subtypes(k), Ref(ktypes))
-    return ktypes
-end
-
 # Fallback implementation of evaluate for `SimpleKernel`s.
 (k::SimpleKernel)(x, y) = kappa(k, evaluate(metric(k), x, y))

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -11,12 +11,5 @@ function concretetypes(k, ktypes::Vector)
     return ktypes
 end
 
-for k in nameof.(subtypes(BaseKernel))
-    @eval begin
-        @deprecate($k(ρ::Real;args...),transform($k(args...),ρ))
-        @deprecate($k(ρ::AbstractVector{<:Real};args...),transform($k(args...),ρ))
-    end
-end
-
 # Fallback implementation of evaluate for `SimpleKernel`s.
 (k::SimpleKernel)(x, y) = kappa(k, evaluate(metric(k), x, y))

--- a/test/matrix/kernelmatrix.jl
+++ b/test/matrix/kernelmatrix.jl
@@ -1,6 +1,6 @@
 # Custom Kernel implementation that only defines how to evaluate itself. This is used to
 # test that fallback kernelmatrix / kerneldiagmatrix methods work properly.
-struct BaseSE <: KernelFunctions.BaseKernel end
+struct BaseSE <: KernelFunctions.Kernel end
 (k::BaseSE)(x, y) = exp(-evaluate(SqEuclidean(), x, y))
 
 # Custom kernel to test `SimpleKernel` interface on, independently the `SimpleKernel`s that
@@ -90,7 +90,7 @@ KernelFunctions.kappa(::ToySimpleKernel, d) = exp(-d / 2)
 
             tmp_diag = Vector{Float64}(undef, length(x))
             @test kerneldiagmatrix!(tmp_diag, k, x) ≈ kerneldiagmatrix(k, x)
-            @test_throws DimensionMismatch kerneldiagmatrix!(tmp_diag, k, y)            
+            @test_throws DimensionMismatch kerneldiagmatrix!(tmp_diag, k, y)
         end
     end
 

--- a/test/mokernels/independent.jl
+++ b/test/mokernels/independent.jl
@@ -5,7 +5,7 @@
     k = IndependentMOKernel(GaussianKernel())
     @test k isa IndependentMOKernel
     @test k isa Kernel
-    @test k.kernel isa KernelFunctions.BaseKernel
+    @test k.kernel isa KernelFunctions.Kernel
     @test k(x[2], y[2]) isa Real
 
     @test kernelmatrix(k, x, y) == kernelmatrix(k, collect(x), collect(y))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Test
 using Flux
 import Zygote, ForwardDiff, ReverseDiff, FiniteDifferences
 
-using KernelFunctions: metric, kappa, ColVecs, RowVecs
+using KernelFunctions: SimpleKernel, metric, kappa, ColVecs, RowVecs
 
 # Writing tests:
 # 1. The file structure of the test should match precisely the file structure of src.


### PR DESCRIPTION
Following #149, this removes BaseKernel as well as the transition for deprecated constructors