### PR TITLE
SelectTransform extended to Symbols

### DIFF
--- a/src/transform/selecttransform.jl
+++ b/src/transform/selecttransform.jl
@@ -1,7 +1,8 @@
 """
-    SelectTransform(dims::AbstractVector{Int})
+    SelectTransform(dims::Union{AbstractVector{Int}, AbstractVector{Symbol}})
 
-Select the dimensions `dims` that the kernel is applied to.
+Select the dimensions `dims` that the kernel is applied to. `dims` can be either all
+integers or symbols.
 ```
     dims = [1,3,5,6,7]
     tr = SelectTransform(dims)
@@ -9,17 +10,17 @@ Select the dimensions `dims` that the kernel is applied to.
     transform(tr,X,obsdim=2) == X[dims,:]
 ```
 """
-struct SelectTransform{T<:AbstractVector{Int}} <: Transform
+struct SelectTransform{T<:Union{AbstractVector{Int}, AbstractVector{Symbol}}} <: Transform
     select::T
-    function SelectTransform{V}(dims::V) where {V<:AbstractVector{Int}}
-        @assert all(dims .> 0) "Selective dimensions should all be positive integers"
-        return new{V}(dims)
-    end
 end
 
-SelectTransform(x::T) where {T<:AbstractVector{Int}} = SelectTransform{T}(x)
+function SelectTransform(dims::T) where {T<:AbstractVector{Int}}
+    @assert all(dims .> 0) "Selective dimensions should all be positive integers"
+    return SelectTransform{T}(dims)
+end
 
 set!(t::SelectTransform{<:AbstractVector{T}}, dims::AbstractVector{T}) where {T<:Int} = t.select .= dims
+set!(t::SelectTransform{<:AbstractVector{T}}, dims::AbstractVector{T}) where {T<:Symbol} = t.select .= dims
 
 duplicate(t::SelectTransform,θ) = t
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
@@ -13,6 +14,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
+AxisArrays = "0.4.3"
 Distances = "0.9"
 FiniteDifferences = "0.10.8"
 Flux = "0.10, 0.11"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using KernelFunctions
+using AxisArrays
 using Distances
 using Kronecker
 using LinearAlgebra

--- a/test/transform/selecttransform.jl
+++ b/test/transform/selecttransform.jl
@@ -8,16 +8,41 @@
     x_cols = ColVecs(randn(rng, maximum(select), 6))
     x_rows = RowVecs(randn(rng, 4, maximum(select)))
 
-    @testset "$(typeof(x))" for x in [x_vecs, x_cols, x_rows]
+    Xs = [x_vecs, x_cols, x_rows]
+
+    @testset "$(typeof(x))" for x in Xs
         x′ = map(t, x)
         @test all([t(x[n]) == x[n][select] for n in eachindex(x)])
         @test all([t(x[n]) == x′[n] for n in eachindex(x)])
+    end
+
+    symbols = [:a, :b, :c, :d, :e]
+    select_symbols = [:a, :c, :e]
+
+    ts = SelectTransform(select_symbols)
+
+    a_vecs = map(x->AxisArray(x, col=symbols), x_vecs)
+    a_cols = ColVecs(AxisArray(x_cols.X, col=symbols, index=(1:6)))
+    a_rows = RowVecs(AxisArray(x_rows.X, index=(1:4), col=symbols))
+
+    As = [a_vecs, a_cols, a_rows]
+
+    @testset "$(typeof(a))" for (a, x) in zip(As, Xs)
+        a′ = map(ts, a)
+        x′ = map(t, x)
+        @test a′ == x′ 
     end
 
     select2 = [2, 3, 5]
     KernelFunctions.set!(t, select2)
     @test t.select == select2
 
+    select_symbols2 = [:b, :c, :e]
+    KernelFunctions.set!(ts, select_symbols2)
+    @test ts.select == select_symbols2
+
     @test repr(t) == "Select Transform (dims: $(select2))"
+    @test repr(ts) == "Select Transform (dims: $(select_symbols2))"
+
     test_ADs(()->transform(SEKernel(), SelectTransform([1,2])))
 end


### PR DESCRIPTION
`SelectTransform` functionality is extended to `Symbol`s making it applicable to `AxisArrays`.