### PR TITLE
Implement periodic transform

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -38,7 +38,7 @@ export TransformedKernel, ScaledKernel
 export TensorProduct
 
 export Transform, SelectTransform, ChainTransform, ScaleTransform, LinearTransform,
-    ARDTransform, IdentityTransform, FunctionTransform
+    ARDTransform, IdentityTransform, FunctionTransform, PeriodicTransform
 
 export NystromFact, nystrom
 
@@ -57,10 +57,6 @@ using StatsFuns: logtwo
 using InteractiveUtils: subtypes
 using StatsBase
 
-"""
-Abstract type defining a slice-wise transformation on an input matrix
-"""
-abstract type Transform end
 
 abstract type Kernel end
 abstract type SimpleKernel <: Kernel end
@@ -70,7 +66,15 @@ include(joinpath("distances", "pairwise.jl"))
 include(joinpath("distances", "dotproduct.jl"))
 include(joinpath("distances", "delta.jl"))
 include(joinpath("distances", "sinus.jl"))
+
 include(joinpath("transform", "transform.jl"))
+include(joinpath("transform", "scaletransform.jl"))
+include(joinpath("transform", "ardtransform.jl"))
+include(joinpath("transform", "lineartransform.jl"))
+include(joinpath("transform", "functiontransform.jl"))
+include(joinpath("transform", "selecttransform.jl"))
+include(joinpath("transform", "chaintransform.jl"))
+include(joinpath("transform", "periodic_transform.jl"))
 
 include(joinpath("basekernels", "constant.jl"))
 include(joinpath("basekernels", "cosine.jl"))

--- a/src/transform/periodic_transform.jl
+++ b/src/transform/periodic_transform.jl
@@ -1,7 +1,8 @@
 """
-    PeriodicTransform{Tf<:Ref{<:Real}} <: Transform
+    PeriodicTransform(f)
 
-Makes a kernel periodic by transforming an input to be periodic.
+Makes a kernel periodic by mapping a scalar input onto the unit circle. Samples from a GP
+with a kernel with this transformation applied will produce samples with frequenct `f`.
 """
 struct PeriodicTransform{Tf<:Ref{<:Real}} <: Transform
     f::Tf
@@ -13,7 +14,7 @@ PeriodicTransform(f::Real) = PeriodicTransform(Ref(f))
 
 dim(t::PeriodicTransform) = 2
 
-(t::PeriodicTransform)(x::Real) = [cosp((2 * t.f[]) * x), sinpi((2 * t.f[]) * x)]
+(t::PeriodicTransform)(x::Real) = [cospi((2 * t.f[]) * x), sinpi((2 * t.f[]) * x)]
 
 function _map(t::PeriodicTransform, x::AbstractVector{<:Real})
     return RowVecs(hcat(cospi.((2 * t.f[]) .* x), sinpi.((2 * t.f[]) .* x)))

--- a/src/transform/periodic_transform.jl
+++ b/src/transform/periodic_transform.jl
@@ -4,24 +4,26 @@
 Makes a kernel periodic by mapping a scalar input onto the unit circle. Samples from a GP
 with a kernel with this transformation applied will produce samples with frequenct `f`.
 """
-struct PeriodicTransform{Tf<:Ref{<:Real}} <: Transform
+struct PeriodicTransform{Tf<:AbstractVector{<:Real}} <: Transform
     f::Tf
 end
 
 @functor PeriodicTransform
 
-PeriodicTransform(f::Real) = PeriodicTransform(Ref(f))
+PeriodicTransform(f::Real) = PeriodicTransform([f])
 
 dim(t::PeriodicTransform) = 2
 
-(t::PeriodicTransform)(x::Real) = [sinpi((2 * t.f[]) * x), cospi((2 * t.f[]) * x)]
+(t::PeriodicTransform)(x::Real) = [sinpi(2 * first(t.f) * x), cospi(2 * first(t.f) * x)]
 
 function _map(t::PeriodicTransform, x::AbstractVector{<:Real})
-    return RowVecs(hcat(sinpi.((2 * t.f[]) .* x), cospi.((2 * t.f[]) .* x)))
+    return RowVecs(hcat(sinpi.((2 * first(t.f)) .* x), cospi.((2 * first(t.f)) .* x)))
 end
 
-Base.isequal(t1::PeriodicTransform, t2::PeriodicTransform) = isequal(t1.f[], t2.f[])
+function Base.isequal(t1::PeriodicTransform, t2::PeriodicTransform)
+    return isequal(first(t1.f), first(t2.f))
+end
 
 function Base.show(io::IO, t::PeriodicTransform)
-    print(io, "Periodic Transform with frequency $(t.f[])")
+    print(io, "Periodic Transform with frequency $(first(t.f))")
 end

--- a/src/transform/periodic_transform.jl
+++ b/src/transform/periodic_transform.jl
@@ -1,0 +1,26 @@
+"""
+    PeriodicTransform{Tf<:Ref{<:Real}} <: Transform
+
+Makes a kernel periodic by transforming an input to be periodic.
+"""
+struct PeriodicTransform{Tf<:Ref{<:Real}} <: Transform
+    f::Tf
+end
+
+@functor PeriodicTransform
+
+PeriodicTransform(f::Real) = PeriodicTransform(Ref(f))
+
+dim(t::PeriodicTransform) = 2
+
+(t::PeriodicTransform)(x::Real) = [cosp((2 * t.f[]) * x), sinpi((2 * t.f[]) * x)]
+
+function _map(t::PeriodicTransform, x::AbstractVector{<:Real})
+    return RowVecs(hcat(cospi.((2 * t.f[]) .* x), sinpi.((2 * t.f[]) .* x)))
+end
+
+Base.isequal(t1::PeriodicTransform, t2::PeriodicTransform) = isequal(t1.f[], t2.f[])
+
+function Base.show(io::IO, t::PeriodicTransform)
+    print(io, "Periodic Transform with frequency $(t.f[])")
+end

--- a/src/transform/periodic_transform.jl
+++ b/src/transform/periodic_transform.jl
@@ -2,7 +2,7 @@
     PeriodicTransform(f)
 
 Makes a kernel periodic by mapping a scalar input onto the unit circle. Samples from a GP
-with a kernel with this transformation applied will produce samples with frequenct `f`.
+with a kernel with this transformation applied will produce samples with frequency `f`.
 """
 struct PeriodicTransform{Tf<:AbstractVector{<:Real}} <: Transform
     f::Tf

--- a/src/transform/periodic_transform.jl
+++ b/src/transform/periodic_transform.jl
@@ -14,10 +14,10 @@ PeriodicTransform(f::Real) = PeriodicTransform(Ref(f))
 
 dim(t::PeriodicTransform) = 2
 
-(t::PeriodicTransform)(x::Real) = [cospi((2 * t.f[]) * x), sinpi((2 * t.f[]) * x)]
+(t::PeriodicTransform)(x::Real) = [sinpi((2 * t.f[]) * x), cospi((2 * t.f[]) * x)]
 
 function _map(t::PeriodicTransform, x::AbstractVector{<:Real})
-    return RowVecs(hcat(cospi.((2 * t.f[]) .* x), sinpi.((2 * t.f[]) .* x)))
+    return RowVecs(hcat(sinpi.((2 * t.f[]) .* x), cospi.((2 * t.f[]) .* x)))
 end
 
 Base.isequal(t1::PeriodicTransform, t2::PeriodicTransform) = isequal(t1.f[], t2.f[])

--- a/src/transform/transform.jl
+++ b/src/transform/transform.jl
@@ -1,10 +1,7 @@
-include("scaletransform.jl")
-include("ardtransform.jl")
-include("lineartransform.jl")
-include("functiontransform.jl")
-include("selecttransform.jl")
-include("chaintransform.jl")
-
+"""
+Abstract type defining a slice-wise transformation on an input matrix
+"""
+abstract type Transform end
 
 Base.map(t::Transform, x::AbstractVector) = _map(t, x)
 _map(t::Transform, x::AbstractVector) = t.(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,6 +72,8 @@ include("test_utils.jl")
         print(" ")
         include(joinpath("transform", "chaintransform.jl"))
         print(" ")
+        include(joinpath("transform", "periodic_transform.jl"))
+        print(" ")
     end
     @info "Ran tests on Transform"
 

--- a/test/transform/periodic_transform.jl
+++ b/test/transform/periodic_transform.jl
@@ -1,0 +1,16 @@
+@testset "periodic_transform" begin
+    @testset "compare to periodic exponentiated quadratic" begin
+        rng = MersenneTwister(123456)
+        f = rand(rng) + 2.0
+        x = collect(range(0.0, 3.0 / f; length=1_000))
+
+        # Construct in the usual way.
+        k_eq_periodic = transform(PeriodicKernel(; r=[sqrt(0.25)]), f)
+
+        # Construct using the peridic transform.
+        k_eq_transform = transform(SqExponentialKernel(), PeriodicTransform(f))
+
+        @test kernelmatrix(k_eq_periodic, x) ≈ kernelmatrix(k_eq_transform, x)
+        # TODO - add interface_tests once #159 is merged.
+    end
+end


### PR DESCRIPTION
Allows us to periodicise kernels other than the EQ.

Note that the exact translation from this transformation (which does the canonical thing) and the periodic EQ is a bit convoluted. See #172 for discussion.