### PR TITLE
SelectTransform with single index

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/transform/selecttransform.jl
+++ b/src/transform/selecttransform.jl
@@ -17,7 +17,10 @@ set!(t::SelectTransform, dims) = t.select .= dims
 
 duplicate(t::SelectTransform,θ) = t
 
-(t::SelectTransform)(x::AbstractVector) = view(x, t.select)
+(t::SelectTransform)(x::AbstractVector) = _maybe_unwrap(view(x, t.select))
+
+_maybe_unwrap(x) = x
+_maybe_unwrap(x::AbstractArray{<:Any, 0}) = x[]
 
 _map(t::SelectTransform, x::ColVecs) = _wrap(view(x.X, t.select, :), ColVecs)
 _map(t::SelectTransform, x::RowVecs) = _wrap(view(x.X, :, t.select), RowVecs)

--- a/src/transform/selecttransform.jl
+++ b/src/transform/selecttransform.jl
@@ -19,8 +19,8 @@ duplicate(t::SelectTransform,θ) = t
 
 (t::SelectTransform)(x::AbstractVector) = view(x, t.select)
 
-_map(t::SelectTransform, x::ColVecs) = _wrap(view(x.X, t.select, :), typeof(x))
-_map(t::SelectTransform, x::RowVecs) = _wrap(view(x.X, :, t.select), typeof(x))
+_map(t::SelectTransform, x::ColVecs) = _wrap(view(x.X, t.select, :), ColVecs)
+_map(t::SelectTransform, x::RowVecs) = _wrap(view(x.X, :, t.select), RowVecs)
 
 _wrap(x::AbstractVector{<:Real}, ::Any) = x
 _wrap(X::AbstractMatrix{<:Real}, ::Type{T}) where {T} = T(X)

--- a/src/transform/selecttransform.jl
+++ b/src/transform/selecttransform.jl
@@ -19,7 +19,10 @@ duplicate(t::SelectTransform,θ) = t
 
 (t::SelectTransform)(x::AbstractVector) = view(x, t.select)
 
-_map(t::SelectTransform, x::ColVecs) = ColVecs(view(x.X, t.select, :))
-_map(t::SelectTransform, x::RowVecs) = RowVecs(view(x.X, :, t.select))
+_map(t::SelectTransform, x::ColVecs) = _wrap(view(x.X, t.select, :), typeof(x))
+_map(t::SelectTransform, x::RowVecs) = _wrap(view(x.X, :, t.select), typeof(x))
+
+_wrap(x::AbstractVector{<:Real}, ::Any) = x
+_wrap(X::AbstractMatrix{<:Real}, ::Type{T}) where {T} = T(X)
 
 Base.show(io::IO, t::SelectTransform) = print(io, "Select Transform (dims: ", t.select, ")")

--- a/test/transform/selecttransform.jl
+++ b/test/transform/selecttransform.jl
@@ -1,114 +1,114 @@
 @testset "selecttransform" begin
-    # rng = MersenneTwister(123456)
+    rng = MersenneTwister(123456)
 
-    # select = [1, 3, 5]
-    # t = SelectTransform(select)
+    select = [1, 3, 5]
+    t = SelectTransform(select)
 
-    # x_vecs = [randn(rng, maximum(select)) for _ in 1:3]
-    # x_cols = ColVecs(randn(rng, maximum(select), 6))
-    # x_rows = RowVecs(randn(rng, 4, maximum(select)))
+    x_vecs = [randn(rng, maximum(select)) for _ in 1:3]
+    x_cols = ColVecs(randn(rng, maximum(select), 6))
+    x_rows = RowVecs(randn(rng, 4, maximum(select)))
 
-    # Xs = [x_vecs, x_cols, x_rows]
+    Xs = [x_vecs, x_cols, x_rows]
 
-    # @testset "$(typeof(x))" for x in Xs
-    #     x′ = map(t, x)
-    #     @test all([t(x[n]) == x[n][select] for n in eachindex(x)])
-    #     @test all([t(x[n]) == x′[n] for n in eachindex(x)])
-    # end
+    @testset "$(typeof(x))" for x in Xs
+        x′ = map(t, x)
+        @test all([t(x[n]) == x[n][select] for n in eachindex(x)])
+        @test all([t(x[n]) == x′[n] for n in eachindex(x)])
+    end
 
-    # symbols = [:a, :b, :c, :d, :e]
-    # select_symbols = [:a, :c, :e]
+    symbols = [:a, :b, :c, :d, :e]
+    select_symbols = [:a, :c, :e]
 
-    # ts = SelectTransform(select_symbols)
+    ts = SelectTransform(select_symbols)
 
-    # a_vecs = map(x->AxisArray(x, col=symbols), x_vecs)
-    # a_cols = ColVecs(AxisArray(x_cols.X, col=symbols, index=(1:6)))
-    # a_rows = RowVecs(AxisArray(x_rows.X, index=(1:4), col=symbols))
+    a_vecs = map(x->AxisArray(x, col=symbols), x_vecs)
+    a_cols = ColVecs(AxisArray(x_cols.X, col=symbols, index=(1:6)))
+    a_rows = RowVecs(AxisArray(x_rows.X, index=(1:4), col=symbols))
 
-    # As = [a_vecs, a_cols, a_rows]
+    As = [a_vecs, a_cols, a_rows]
 
-    # @testset "$(typeof(a))" for (a, x) in zip(As, Xs)
-    #     a′ = map(ts, a)
-    #     x′ = map(t, x)
-    #     @test a′ == x′ 
-    # end
+    @testset "$(typeof(a))" for (a, x) in zip(As, Xs)
+        a′ = map(ts, a)
+        x′ = map(t, x)
+        @test a′ == x′ 
+    end
 
-    # select2 = [2, 3, 5]
-    # KernelFunctions.set!(t, select2)
-    # @test t.select == select2
+    select2 = [2, 3, 5]
+    KernelFunctions.set!(t, select2)
+    @test t.select == select2
 
-    # select_symbols2 = [:b, :c, :e]
-    # KernelFunctions.set!(ts, select_symbols2)
-    # @test ts.select == select_symbols2
+    select_symbols2 = [:b, :c, :e]
+    KernelFunctions.set!(ts, select_symbols2)
+    @test ts.select == select_symbols2
 
-    # @test repr(t) == "Select Transform (dims: $(select2))"
-    # @test repr(ts) == "Select Transform (dims: $(select_symbols2))"
+    @test repr(t) == "Select Transform (dims: $(select2))"
+    @test repr(ts) == "Select Transform (dims: $(select_symbols2))"
 
-    # test_ADs(()->transform(SEKernel(), SelectTransform([1,2])))
+    test_ADs(()->transform(SEKernel(), SelectTransform([1,2])))
 
-    # X = randn(rng, (4, 3))
-    # A = AxisArray(X, row=[:a, :b, :c, :d], col=[:x, :y, :z])
-    # Y = randn(rng, (4, 2))
-    # B = AxisArray(Y, row=[:a, :b, :c, :d], col=[:v, :w])
-    # Z = randn(rng, (2, 3))
-    # C = AxisArray(Z, row=[:e, :f], col=[:x, :y, :z])
+    X = randn(rng, (4, 3))
+    A = AxisArray(X, row=[:a, :b, :c, :d], col=[:x, :y, :z])
+    Y = randn(rng, (4, 2))
+    B = AxisArray(Y, row=[:a, :b, :c, :d], col=[:v, :w])
+    Z = randn(rng, (2, 3))
+    C = AxisArray(Z, row=[:e, :f], col=[:x, :y, :z])
 
-    # tx_row = transform(SEKernel(), SelectTransform([1,2,4]))
-    # ta_row = transform(SEKernel(), SelectTransform([:a,:b,:d]))
-    # tx_col = transform(SEKernel(), SelectTransform([1,3]))
-    # ta_col = transform(SEKernel(), SelectTransform([:x,:z]))
+    tx_row = transform(SEKernel(), SelectTransform([1,2,4]))
+    ta_row = transform(SEKernel(), SelectTransform([:a,:b,:d]))
+    tx_col = transform(SEKernel(), SelectTransform([1,3]))
+    ta_col = transform(SEKernel(), SelectTransform([:x,:z]))
 
-    # @test kernelmatrix(tx_row, X, obsdim=2) == kernelmatrix(ta_row, A, obsdim=2)
-    # @test kernelmatrix(tx_col, X, obsdim=1) == kernelmatrix(ta_col, A, obsdim=1)
+    @test kernelmatrix(tx_row, X, obsdim=2) == kernelmatrix(ta_row, A, obsdim=2)
+    @test kernelmatrix(tx_col, X, obsdim=1) == kernelmatrix(ta_col, A, obsdim=1)
 
-    # @test kernelmatrix(tx_row, X, Y, obsdim=2) == kernelmatrix(ta_row, A, B, obsdim=2)
-    # @test kernelmatrix(tx_col, X, Z, obsdim=1) == kernelmatrix(ta_col, A, C, obsdim=1)
+    @test kernelmatrix(tx_row, X, Y, obsdim=2) == kernelmatrix(ta_row, A, B, obsdim=2)
+    @test kernelmatrix(tx_col, X, Z, obsdim=1) == kernelmatrix(ta_col, A, C, obsdim=1)
 
-    # @testset "$(AD)" for AD in [:Zygote, :ForwardDiff]
-    #     gx = gradient(AD, X) do x
-    #         testfunction(tx_row, x, 2)
-    #     end
-    #     ga = gradient(AD, A) do a
-    #         testfunction(ta_row, a, 2)
-    #     end
-    #     @test gx == ga
-    #     gx = gradient(AD, X) do x
-    #         testfunction(tx_col, x, 1)
-    #     end
-    #     ga = gradient(AD, A) do a
-    #         testfunction(ta_col, a, 1)
-    #     end
-    #     @test gx == ga
-    #     gx = gradient(AD, X) do x
-    #         testfunction(tx_row, x, Y, 2)
-    #     end
-    #     ga = gradient(AD, A) do a
-    #         testfunction(ta_row, a, B, 2)
-    #     end
-    #     @test gx == ga
-    #     gx = gradient(AD, X) do x
-    #         testfunction(tx_col, x, Z, 1)
-    #     end
-    #     ga = gradient(AD, A) do a
-    #         testfunction(ta_col, a, C, 1)
-    #     end
-    #     @test gx == ga
-    # end
+    @testset "$(AD)" for AD in [:Zygote, :ForwardDiff]
+        gx = gradient(AD, X) do x
+            testfunction(tx_row, x, 2)
+        end
+        ga = gradient(AD, A) do a
+            testfunction(ta_row, a, 2)
+        end
+        @test gx == ga
+        gx = gradient(AD, X) do x
+            testfunction(tx_col, x, 1)
+        end
+        ga = gradient(AD, A) do a
+            testfunction(ta_col, a, 1)
+        end
+        @test gx == ga
+        gx = gradient(AD, X) do x
+            testfunction(tx_row, x, Y, 2)
+        end
+        ga = gradient(AD, A) do a
+            testfunction(ta_row, a, B, 2)
+        end
+        @test gx == ga
+        gx = gradient(AD, X) do x
+            testfunction(tx_col, x, Z, 1)
+        end
+        ga = gradient(AD, A) do a
+            testfunction(ta_col, a, C, 1)
+        end
+        @test gx == ga
+    end
 
-    # @testset "$(AD)" for AD in [:ReverseDiff]
-    #     @test_broken ga = gradient(AD, A) do a
-    #         testfunction(ta_row, a, 2)
-    #     end
-    #     @test_broken ga = gradient(AD, A) do a
-    #         testfunction(ta_col, a, 1)
-    #     end
-    #     @test_broken ga = gradient(AD, A) do a
-    #         testfunction(ta_row, a, B, 2)
-    #     end
-    #     @test_broken ga = gradient(AD, A) do a
-    #         testfunction(ta_col, a, C, 1)
-    #     end
-    # end
+    @testset "$(AD)" for AD in [:ReverseDiff]
+        @test_broken ga = gradient(AD, A) do a
+            testfunction(ta_row, a, 2)
+        end
+        @test_broken ga = gradient(AD, A) do a
+            testfunction(ta_col, a, 1)
+        end
+        @test_broken ga = gradient(AD, A) do a
+            testfunction(ta_row, a, B, 2)
+        end
+        @test_broken ga = gradient(AD, A) do a
+            testfunction(ta_col, a, C, 1)
+        end
+    end
 
     @testset "single-index" begin
         t = SelectTransform(4)

--- a/test/transform/selecttransform.jl
+++ b/test/transform/selecttransform.jl
@@ -113,6 +113,7 @@
     @testset "single-index" begin
         t = SelectTransform(4)
         @testset "$(name)" for (name, x) in [
+            ("Vector{<:Vector}", [randn(6) for _ in 1:3]),
             ("ColVecs", ColVecs(randn(5, 10))),
             ("RowVecs", RowVecs(randn(11, 4))),
         ]

--- a/test/transform/selecttransform.jl
+++ b/test/transform/selecttransform.jl
@@ -1,112 +1,122 @@
 @testset "selecttransform" begin
-    rng = MersenneTwister(123456)
+    # rng = MersenneTwister(123456)
 
-    select = [1, 3, 5]
-    t = SelectTransform(select)
+    # select = [1, 3, 5]
+    # t = SelectTransform(select)
 
-    x_vecs = [randn(rng, maximum(select)) for _ in 1:3]
-    x_cols = ColVecs(randn(rng, maximum(select), 6))
-    x_rows = RowVecs(randn(rng, 4, maximum(select)))
+    # x_vecs = [randn(rng, maximum(select)) for _ in 1:3]
+    # x_cols = ColVecs(randn(rng, maximum(select), 6))
+    # x_rows = RowVecs(randn(rng, 4, maximum(select)))
 
-    Xs = [x_vecs, x_cols, x_rows]
+    # Xs = [x_vecs, x_cols, x_rows]
 
-    @testset "$(typeof(x))" for x in Xs
-        x′ = map(t, x)
-        @test all([t(x[n]) == x[n][select] for n in eachindex(x)])
-        @test all([t(x[n]) == x′[n] for n in eachindex(x)])
-    end
+    # @testset "$(typeof(x))" for x in Xs
+    #     x′ = map(t, x)
+    #     @test all([t(x[n]) == x[n][select] for n in eachindex(x)])
+    #     @test all([t(x[n]) == x′[n] for n in eachindex(x)])
+    # end
 
-    symbols = [:a, :b, :c, :d, :e]
-    select_symbols = [:a, :c, :e]
+    # symbols = [:a, :b, :c, :d, :e]
+    # select_symbols = [:a, :c, :e]
 
-    ts = SelectTransform(select_symbols)
+    # ts = SelectTransform(select_symbols)
 
-    a_vecs = map(x->AxisArray(x, col=symbols), x_vecs)
-    a_cols = ColVecs(AxisArray(x_cols.X, col=symbols, index=(1:6)))
-    a_rows = RowVecs(AxisArray(x_rows.X, index=(1:4), col=symbols))
+    # a_vecs = map(x->AxisArray(x, col=symbols), x_vecs)
+    # a_cols = ColVecs(AxisArray(x_cols.X, col=symbols, index=(1:6)))
+    # a_rows = RowVecs(AxisArray(x_rows.X, index=(1:4), col=symbols))
 
-    As = [a_vecs, a_cols, a_rows]
+    # As = [a_vecs, a_cols, a_rows]
 
-    @testset "$(typeof(a))" for (a, x) in zip(As, Xs)
-        a′ = map(ts, a)
-        x′ = map(t, x)
-        @test a′ == x′ 
-    end
+    # @testset "$(typeof(a))" for (a, x) in zip(As, Xs)
+    #     a′ = map(ts, a)
+    #     x′ = map(t, x)
+    #     @test a′ == x′ 
+    # end
 
-    select2 = [2, 3, 5]
-    KernelFunctions.set!(t, select2)
-    @test t.select == select2
+    # select2 = [2, 3, 5]
+    # KernelFunctions.set!(t, select2)
+    # @test t.select == select2
 
-    select_symbols2 = [:b, :c, :e]
-    KernelFunctions.set!(ts, select_symbols2)
-    @test ts.select == select_symbols2
+    # select_symbols2 = [:b, :c, :e]
+    # KernelFunctions.set!(ts, select_symbols2)
+    # @test ts.select == select_symbols2
 
-    @test repr(t) == "Select Transform (dims: $(select2))"
-    @test repr(ts) == "Select Transform (dims: $(select_symbols2))"
+    # @test repr(t) == "Select Transform (dims: $(select2))"
+    # @test repr(ts) == "Select Transform (dims: $(select_symbols2))"
 
-    test_ADs(()->transform(SEKernel(), SelectTransform([1,2])))
+    # test_ADs(()->transform(SEKernel(), SelectTransform([1,2])))
 
-    X = randn(rng, (4, 3))
-    A = AxisArray(X, row=[:a, :b, :c, :d], col=[:x, :y, :z])
-    Y = randn(rng, (4, 2))
-    B = AxisArray(Y, row=[:a, :b, :c, :d], col=[:v, :w])
-    Z = randn(rng, (2, 3))
-    C = AxisArray(Z, row=[:e, :f], col=[:x, :y, :z])
+    # X = randn(rng, (4, 3))
+    # A = AxisArray(X, row=[:a, :b, :c, :d], col=[:x, :y, :z])
+    # Y = randn(rng, (4, 2))
+    # B = AxisArray(Y, row=[:a, :b, :c, :d], col=[:v, :w])
+    # Z = randn(rng, (2, 3))
+    # C = AxisArray(Z, row=[:e, :f], col=[:x, :y, :z])
 
-    tx_row = transform(SEKernel(), SelectTransform([1,2,4]))
-    ta_row = transform(SEKernel(), SelectTransform([:a,:b,:d]))
-    tx_col = transform(SEKernel(), SelectTransform([1,3]))
-    ta_col = transform(SEKernel(), SelectTransform([:x,:z]))
+    # tx_row = transform(SEKernel(), SelectTransform([1,2,4]))
+    # ta_row = transform(SEKernel(), SelectTransform([:a,:b,:d]))
+    # tx_col = transform(SEKernel(), SelectTransform([1,3]))
+    # ta_col = transform(SEKernel(), SelectTransform([:x,:z]))
 
-    @test kernelmatrix(tx_row, X, obsdim=2) == kernelmatrix(ta_row, A, obsdim=2)
-    @test kernelmatrix(tx_col, X, obsdim=1) == kernelmatrix(ta_col, A, obsdim=1)
+    # @test kernelmatrix(tx_row, X, obsdim=2) == kernelmatrix(ta_row, A, obsdim=2)
+    # @test kernelmatrix(tx_col, X, obsdim=1) == kernelmatrix(ta_col, A, obsdim=1)
 
-    @test kernelmatrix(tx_row, X, Y, obsdim=2) == kernelmatrix(ta_row, A, B, obsdim=2)
-    @test kernelmatrix(tx_col, X, Z, obsdim=1) == kernelmatrix(ta_col, A, C, obsdim=1)
+    # @test kernelmatrix(tx_row, X, Y, obsdim=2) == kernelmatrix(ta_row, A, B, obsdim=2)
+    # @test kernelmatrix(tx_col, X, Z, obsdim=1) == kernelmatrix(ta_col, A, C, obsdim=1)
 
-    @testset "$(AD)" for AD in [:Zygote, :ForwardDiff]
-        gx = gradient(AD, X) do x
-            testfunction(tx_row, x, 2)
-        end
-        ga = gradient(AD, A) do a
-            testfunction(ta_row, a, 2)
-        end
-        @test gx == ga
-        gx = gradient(AD, X) do x
-            testfunction(tx_col, x, 1)
-        end
-        ga = gradient(AD, A) do a
-            testfunction(ta_col, a, 1)
-        end
-        @test gx == ga
-        gx = gradient(AD, X) do x
-            testfunction(tx_row, x, Y, 2)
-        end
-        ga = gradient(AD, A) do a
-            testfunction(ta_row, a, B, 2)
-        end
-        @test gx == ga
-        gx = gradient(AD, X) do x
-            testfunction(tx_col, x, Z, 1)
-        end
-        ga = gradient(AD, A) do a
-            testfunction(ta_col, a, C, 1)
-        end
-        @test gx == ga
-    end
+    # @testset "$(AD)" for AD in [:Zygote, :ForwardDiff]
+    #     gx = gradient(AD, X) do x
+    #         testfunction(tx_row, x, 2)
+    #     end
+    #     ga = gradient(AD, A) do a
+    #         testfunction(ta_row, a, 2)
+    #     end
+    #     @test gx == ga
+    #     gx = gradient(AD, X) do x
+    #         testfunction(tx_col, x, 1)
+    #     end
+    #     ga = gradient(AD, A) do a
+    #         testfunction(ta_col, a, 1)
+    #     end
+    #     @test gx == ga
+    #     gx = gradient(AD, X) do x
+    #         testfunction(tx_row, x, Y, 2)
+    #     end
+    #     ga = gradient(AD, A) do a
+    #         testfunction(ta_row, a, B, 2)
+    #     end
+    #     @test gx == ga
+    #     gx = gradient(AD, X) do x
+    #         testfunction(tx_col, x, Z, 1)
+    #     end
+    #     ga = gradient(AD, A) do a
+    #         testfunction(ta_col, a, C, 1)
+    #     end
+    #     @test gx == ga
+    # end
 
-    @testset "$(AD)" for AD in [:ReverseDiff]
-        @test_broken ga = gradient(AD, A) do a
-            testfunction(ta_row, a, 2)
-        end
-        @test_broken ga = gradient(AD, A) do a
-            testfunction(ta_col, a, 1)
-        end
-        @test_broken ga = gradient(AD, A) do a
-            testfunction(ta_row, a, B, 2)
-        end
-        @test_broken ga = gradient(AD, A) do a
-            testfunction(ta_col, a, C, 1)
+    # @testset "$(AD)" for AD in [:ReverseDiff]
+    #     @test_broken ga = gradient(AD, A) do a
+    #         testfunction(ta_row, a, 2)
+    #     end
+    #     @test_broken ga = gradient(AD, A) do a
+    #         testfunction(ta_col, a, 1)
+    #     end
+    #     @test_broken ga = gradient(AD, A) do a
+    #         testfunction(ta_row, a, B, 2)
+    #     end
+    #     @test_broken ga = gradient(AD, A) do a
+    #         testfunction(ta_col, a, C, 1)
+    #     end
+    # end
+
+    @testset "single-index" begin
+        t = SelectTransform(4)
+        @testset "$(name)" for (name, x) in [
+            ("ColVecs", ColVecs(randn(5, 10))),
+            ("RowVecs", RowVecs(randn(11, 4))),
+        ]
+            @test KernelFunctions._map(t, x) isa AbstractVector{Float64}
         end
     end
 end


### PR DESCRIPTION
The output `SelectTransform(5)(some_vector)` should really be a scalar, however, this currently doesn't work. It is important that this works so that (for example) a single dimension of a vector-valued input can be passed to kernels that can't handle vector-valued inputs, such as kernels constructed via `PeriodicTransform`.

This PR addresses this issue by making this possible.