### PR TITLE
Update CompatHelper.yml

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,19 +1,16 @@
 name: CompatHelper
-
 on:
   schedule:
     - cron: '00 00 * * *'
-
+  workflow_dispatch:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: 1.3
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
         run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs = ["", "docs", "test"])'


### PR DESCRIPTION
This PR updates CompatHelper. Currently CompatHelper is not allowed to trigger CI tests (see https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/pull/199 and https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/pull/198).