### PR TITLE
Link to stable documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; url=http://juliagaussianprocesses.github.io/KernelFunctions.jl/dev" />
+<meta http-equiv="refresh" content="0; url=http://juliagaussianprocesses.github.io/KernelFunctions.jl/stable" />


### PR DESCRIPTION
I noticed that currently http://juliagaussianprocesses.github.io/KernelFunctions.jl/ links to the unstable docs but I assume it might be better to link to the stable version.