### PR TITLE
Bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.8.10"
+version = "0.8.11"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
I missed that https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/pull/213 should be released as a new patch version since we introduced and exported the alias `Matern12Kernel`.