### PR TITLE
Add GH action for commenting with link to docs preview

### DIFF
--- a/.github/workflows/doc_preview_comment.yml
+++ b/.github/workflows/doc_preview_comment.yml
@@ -1,0 +1,14 @@
+name: Documentation Preview Comment # Write a comment in the PR with a link to the preview of the given website
+on:
+  pull_request:
+    types: [opened, reopened]
+jobs:
+  pr_comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create PR comment
+        if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name # if this is a pull request build AND the pull request is NOT made from a fork
+        uses: thollander/actions-comment-pull-request@71efef56b184328c7ef1f213577c3a90edaa4aff
+        with:
+          message: 'Once the build has completed, you can preview your PR at this URL: https://juliagaussianprocesses.github.io/KernelFunctions.jl/previews/PR${{ github.event.number }}/'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I thought it would be practical to automatically get a comment with a link to the preview of the docs.