### PR TITLE
Fix default degree of `PiecewisePolynomialKernel`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.8.13"
+version = "0.8.14"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.8.14"
+version = "0.8.15"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/basekernels/piecewisepolynomial.jl
+++ b/src/basekernels/piecewisepolynomial.jl
@@ -41,12 +41,13 @@ struct PiecewisePolynomialKernel{D,C<:Tuple} <: SimpleKernel
 end
 
 # TODO: remove `maha` keyword argument in next breaking release
-function PiecewisePolynomialKernel(; v::Int=-1, degree::Int=v, maha=nothing, dim::Int=-1)
+function PiecewisePolynomialKernel(; v::Int=-1, degree::Int=0, maha=nothing, dim::Int=-1)
     if v != -1
         Base.depwarn(
             "keyword argument `v` is deprecated, use `degree` instead",
             :PiecewisePolynomialKernel,
         )
+        degree = v
     end
 
     if maha !== nothing

--- a/test/basekernels/piecewisepolynomial.jl
+++ b/test/basekernels/piecewisepolynomial.jl
@@ -21,6 +21,11 @@
     @test_throws ErrorException PiecewisePolynomialKernel{4}(maha)
     @test_throws ErrorException PiecewisePolynomialKernel{4}(D)
     @test_throws ErrorException PiecewisePolynomialKernel{degree}(-1)
+    @test_throws ErrorException PiecewisePolynomialKernel()
+    @test_throws ErrorException PiecewisePolynomialKernel(; degree=degree)
+
+    # default degree
+    @test PiecewisePolynomialKernel(; dim=D) isa PiecewisePolynomialKernel{0}
 
     @test repr(k) ==
           "Piecewise Polynomial Kernel (degree = $(degree), ⌊dim/2⌋ = $(div(D, 2)))"


### PR DESCRIPTION
This PR fixes the deprecation logic of the keyword arguments of `PiecewisePolynomialKernel`. The default value of `degree` should be 0, not `-1`.