### PR TITLE
Use only docstrings in documentation + fix them

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.8.16"
+version = "0.8.17"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -9,63 +9,6 @@ Pages = ["api.md"]
 CurrentModule = KernelFunctions
 ```
 
-## Module
-```@docs
-KernelFunctions
-```
-
-## Base Kernels API
-
-```@docs
-ConstantKernel
-WhiteKernel
-EyeKernel
-ZeroKernel
-CosineKernel
-SqExponentialKernel
-ExponentialKernel
-GammaExponentialKernel
-ExponentiatedKernel
-FBMKernel
-GaborKernel
-MaternKernel
-Matern32Kernel
-Matern52Kernel
-NeuralNetworkKernel
-LinearKernel
-PolynomialKernel
-PiecewisePolynomialKernel
-RationalQuadraticKernel
-GammaRationalQuadraticKernel
-spectral_mixture_kernel
-spectral_mixture_product_kernel
-PeriodicKernel
-WienerKernel
-```
-
-## Composite Kernels
-
-```@docs
-TransformedKernel
-ScaledKernel
-KernelSum
-KernelProduct
-TensorProduct
-```
-
-## Transforms
-
-```@docs
-Transform
-IdentityTransform
-ScaleTransform
-ARDTransform
-LinearTransform
-FunctionTransform
-SelectTransform
-ChainTransform
-```
-
 ## Functions
 
 ```@docs
@@ -84,6 +27,7 @@ transform
 ```@docs
 ColVecs
 RowVecs
+MOInput
 NystromFact
 ```
 

--- a/docs/src/kernels.md
+++ b/docs/src/kernels.md
@@ -2,11 +2,18 @@
   CurrentModule = KernelFunctions
 ```
 
-# Base Kernels
+# Kernel Functions
+
+```@contents
+Pages = ["kernels.md"]
+Depth = 3
+```
+
+## Base Kernels
 
 These are the basic kernels without any transformation of the data. They are the building blocks of KernelFunctions.
 
-## Constant Kernels
+### Constant Kernels
 
 ```@docs
 ZeroKernel
@@ -15,13 +22,13 @@ WhiteKernel
 EyeKernel
 ```
 
-## Cosine Kernel
+### Cosine Kernel
 
 ```@docs
 CosineKernel
 ```
 
-## Exponential Kernels
+### Exponential Kernels
 
 ```@docs
 ExponentialKernel
@@ -33,25 +40,25 @@ RBFKernel
 GammaExponentialKernel
 ```
 
-## Exponentiated Kernel
+### Exponentiated Kernel
 
 ```@docs
 ExponentiatedKernel
 ```
 
-## Fractional Brownian Motion Kernel
+### Fractional Brownian Motion Kernel
 
 ```@docs
 FBMKernel
 ```
 
-## Gabor Kernel
+### Gabor Kernel
 
 ```@docs
 GaborKernel
 ```
 
-## Matérn Kernels
+### Matérn Kernels
 
 ```@docs
 MaternKernel
@@ -60,53 +67,53 @@ Matern32Kernel
 Matern52Kernel
 ```
 
-## Neural Network Kernel
+### Neural Network Kernel
 
 ```@docs
 NeuralNetworkKernel
 ```
 
-## Periodic Kernel
+### Periodic Kernel
 
 ```@docs
 PeriodicKernel
 PeriodicKernel(::DataType, ::Int)
 ```
 
-## Piecewise Polynomial Kernel
+### Piecewise Polynomial Kernel
 
 ```@docs
 PiecewisePolynomialKernel
 ```
 
-## Polynomial Kernels
+### Polynomial Kernels
 
 ```@docs
 LinearKernel
 PolynomialKernel
 ```
 
-## Rational Quadratic Kernels
+### Rational Quadratic Kernels
 
 ```@docs
 RationalQuadraticKernel
 GammaRationalQuadraticKernel
 ```
 
-## Spectral Mixture Kernels
+### Spectral Mixture Kernels
 
 ```@docs
 spectral_mixture_kernel
 spectral_mixture_product_kernel
 ```
 
-## Wiener Kernel
+### Wiener Kernel
 
 ```@docs
 WienerKernel
 ```
 
-# Composite Kernels
+## Composite Kernels
 
 The modular design of KernelFunctions.jl uses [base kernels](@ref) as building blocks for
 more complex kernels. These composite kernels can be created by adding
@@ -124,7 +131,7 @@ KernelProduct
 TensorProduct
 ```
 
-# Multi-output Kernels
+## Multi-output Kernels
 
 ```@docs
 MOKernel

--- a/docs/src/kernels.md
+++ b/docs/src/kernels.md
@@ -86,7 +86,7 @@ LinearKernel
 PolynomialKernel
 ```
 
-## Rational Quadratic
+## Rational Quadratic Kernels
 
 ```@docs
 RationalQuadraticKernel

--- a/docs/src/kernels.md
+++ b/docs/src/kernels.md
@@ -108,6 +108,11 @@ WienerKernel
 
 # Composite Kernels
 
+The modular design of KernelFunctions.jl uses [base kernels](@ref) as building blocks for
+more complex kernels. These composite kernels can be created by adding
+[input transforms](@ref) such as scaling the inputs with an inverse lengthscale, by scaling the
+variance of a kernel, or by summing or multiplying different kernels.
+
 ```@docs
 TransformedKernel
 transform(::Kernel, ::Transform)

--- a/docs/src/kernels.md
+++ b/docs/src/kernels.md
@@ -6,270 +6,123 @@
 
 These are the basic kernels without any transformation of the data. They are the building blocks of KernelFunctions.
 
-
 ## Constant Kernels
 
-### Constant Kernel
-
-The [`ConstantKernel`](@ref) is defined as
-
-```math
-  k(x,x';c) = c,
-```
-
-where $c \geq 0$.
-
-### White Kernel
-
-The [`WhiteKernel`](@ref) is defined as
-
-```math
-  k(x,x') = \delta(x-x').
-```
-
-### Zero Kernel
-
-The [`ZeroKernel`](@ref) is defined as
-
-```math
-  k(x,x') = 0.
+```@docs
+ZeroKernel
+ConstantKernel
+WhiteKernel
+EyeKernel
 ```
 
 ## Cosine Kernel
 
-The [`CosineKernel`](@ref) is defined as
-
-```math
-  k(x, x') = \cos(\pi \|x-x'\|).
+```@docs
+CosineKernel
 ```
 
 ## Exponential Kernels
 
-### Exponential Kernel
-
-The [`ExponentialKernel`](@ref) is defined as
-```math
-  k(x,x') = \exp\left(-|x-x'|\right).
+```@docs
+ExponentialKernel
+LaplacianKernel
+SqExponentialKernel
+SEKernel
+GaussianKernel
+RBFKernel
+GammaExponentialKernel
 ```
-
-### Square Exponential Kernel
-
-The [`SqExponentialKernel`](@ref) is defined as
-```math
-  k(x,x') = \exp\left(-\|x-x'\|^2\right).
-```
-
-### Gamma Exponential Kernel
-
-The [`GammaExponentialKernel`](@ref) is defined as
-
-```math
-  k(x,x';\gamma) = \exp\left(-\|x-x'\|^{2\gamma}\right),
-```
-where $\gamma > 0$.
 
 ## Exponentiated Kernel
 
-The [`ExponentiatedKernel`](@ref) is defined as
-
-```math
-  k(x,x') = \exp\left(\langle x,x'\rangle\right).
+```@docs
+ExponentiatedKernel
 ```
 
-## Fractional Brownian Motion
+## Fractional Brownian Motion Kernel
 
-The [`FBMKernel`](@ref) is defined as
-
-```math
-  k(x,x';h) =  \frac{|x|^{2h} + |x'|^{2h} - |x-x'|^{2h}}{2},
+```@docs
+FBMKernel
 ```
-
-where $h$ is the [Hurst index](https://en.wikipedia.org/wiki/Hurst_exponent#Generalized_exponent) and $0 < h < 1$.
 
 ## Gabor Kernel
 
-The [`GaborKernel`](@ref) is defined as
-
-```math
-  k(x,x'; l,p) = \exp\left(-\cos\left(\pi \sum_i \frac{x_i - x'_i}{p_i}\right)\sum_i \frac{(x_i - x'_i)^2}{l_i^2}\right),
+```@docs
+GaborKernel
 ```
-where $l_i > 0$ is the lengthscale and $p_i > 0$ is the period.
 
 ## Matérn Kernels
 
-### General Matérn Kernel
-
-The [`MaternKernel`](@ref) is defined as
-
-```math
-  k(x,x';\nu) = \frac{2^{1-\nu}}{\Gamma(\nu)}\left(\sqrt{2\nu}|x-x'|\right)K_\nu\left(\sqrt{2\nu}|x-x'|\right),
-```
-
-where $\nu > 0$.
-
-### Matérn 1/2 Kernel
-
-The Matérn 1/2 kernel is defined as
-```math
-  k(x,x') = \exp\left(-|x-x'|\right),
-```
-equivalent to the Exponential kernel. `Matern12Kernel` is an alias for [`ExponentialKernel`](@ref).
-
-### Matérn 3/2 Kernel
-
-The [`Matern32Kernel`](@ref) is defined as
-
-```math
-  k(x,x') = \left(1+\sqrt{3}|x-x'|\right)\exp\left(\sqrt{3}|x-x'|\right).
-```
-
-### Matérn 5/2 Kernel
-
-The [`Matern52Kernel`](@ref) is defined as
-
-```math
-  k(x,x') = \left(1+\sqrt{5}|x-x'|+\frac{5}{2}\|x-x'\|^2\right)\exp\left(\sqrt{5}|x-x'|\right).
+```@docs
+MaternKernel
+Matern12Kernel
+Matern32Kernel
+Matern52Kernel
 ```
 
 ## Neural Network Kernel
 
-The [`NeuralNetworkKernel`](@ref) (as in the kernel for an infinitely wide neural network interpreted as a Gaussian process) is defined as
-
-```math
-  k(x, x') = \arcsin\left(\frac{\langle x, x'\rangle}{\sqrt{(1+\langle x, x\rangle)(1+\langle x',x'\rangle)}}\right).
+```@docs
+NeuralNetworkKernel
 ```
 
 ## Periodic Kernel
 
-The [`PeriodicKernel`](@ref) is defined as
-
-```math
-  k(x,x';r) = \exp\left(-0.5 \sum_i (\sin (\pi(x_i - x'_i))/r_i)^2\right),
+```@docs
+PeriodicKernel
+PeriodicKernel(::DataType, ::Int)
 ```
-
-where $r$ has the same dimension as $x$ and $r_i > 0$.
 
 ## Piecewise Polynomial Kernel
 
-The [`PiecewisePolynomialKernel`](@ref) of degree $v \in \{0,1,2,3\}$ is defined for
-inputs $x, x' \in \mathbb{R}^d$ of dimension $d$ as
-```math
-k(x, x'; v) = \max(1 - \|x - x'\|, 0)^{\alpha} f_{v,d}(\|x - x'\|),
+```@docs
+PiecewisePolynomialKernel
 ```
-where $\alpha = \lfloor \frac{d}{2}\rfloor + 2v + 1$, and $f_{v,d}$ are polynomials of
-degree $v$ given by
-```math
-\begin{aligned}
-f_{0,d}(r) &= 1, \\
-f_{1,d}(r) &= 1 + (j + 1) r, \\
-f_{2,d}(r) &= 1 + (j + 2) r + \big((j^2 + 4j + 3) / 3\big) r^2, \\
-f_{3,d}(r) &= 1 + (j + 3) r + \big((6 j^2 + 36j + 45) / 15\big) r^2 + \big((j^3 + 9 j^2 + 23j + 15) / 15\big) r^3,
-\end{aligned}
-```
-where $j = \lfloor \frac{d}{2}\rfloor + v + 1$.
 
 ## Polynomial Kernels
 
-### Linear Kernel
-
-The [`LinearKernel`](@ref) is defined as
-
-```math
-  k(x,x';c) = \langle x,x'\rangle + c,
+```@docs
+LinearKernel
+PolynomialKernel
 ```
-
-where $c \geq 0$.
-
-### Polynomial Kernel
-
-The [`PolynomialKernel`](@ref) is defined as
-
-```math
-  k(x,x';c,d) = \left(\langle x,x'\rangle + c\right)^d,
-```
-
-where $c \geq 0$ and $d \in \mathbb{N}$.
 
 ## Rational Quadratic
 
-### Rational Quadratic Kernel
-
-The [`RationalQuadraticKernel`](@ref) is defined as
-
-```math
-  k(x,x';\alpha) = \left(1+\frac{\|x-x'\|^2}{\alpha}\right)^{-\alpha},
+```@docs
+RationalQuadraticKernel
+GammaRationalQuadraticKernel
 ```
 
-where $\alpha > 0$.
+## Spectral Mixture Kernels
 
-### Gamma Rational Quadratic Kernel
-
-The [`GammaRationalQuadraticKernel`](@ref) is defined as
-
-```math
-  k(x,x';\alpha,\gamma) = \left(1+\frac{\|x-x'\|^{2\gamma}}{\alpha}\right)^{-\alpha},
+```@docs
+spectral_mixture_kernel
+spectral_mixture_product_kernel
 ```
-
-where $\alpha > 0$ and $\gamma > 0$.
-
-## Spectral Mixture Kernel
-
-The spectral mixture kernel is called by [`spectral_mixture_kernel`](@ref).
-
 
 ## Wiener Kernel
 
-The [`WienerKernel`](@ref) is defined as
-
-```math
-k(x,x';i) = \left\{\begin{array}{cc}
-  \delta(x, x') & i = -1\\
-  \min(x,x') & i = 0\\
-  \frac{\min(x,x')^{2i+1}}{a_i} + b_i \min(x,x')^{i+1}|x-x'|r_i(x,x') & i\geq 1
-\end{array}\right.,
+```@docs
+WienerKernel
 ```
-where $i\in\{-1,0,1,2,3\}$ and coefficients $a_i$, $b_i$ are fixed and residuals $r_i$ are defined in the code.
 
 # Composite Kernels
 
-### Transformed Kernel
-
-The [`TransformedKernel`](@ref) is a kernel where inputs are transformed via a function `f`:
-
-```math
-  k(x,x';f,\widetilde{k}) = \widetilde{k}(f(x),f(x')),
-```
-where $\widetilde{k}$ is another kernel and $f$ is an arbitrary mapping.
-
-### Scaled Kernel
-
-The [`ScaledKernel`](@ref) is defined as
-
-```math
-  k(x,x';\sigma^2,\widetilde{k}) = \sigma^2\widetilde{k}(x,x') ,
-```
-where $\widetilde{k}$ is another kernel and $\sigma^2 > 0$.
-
-### Kernel Sum
-
-The [`KernelSum`](@ref) is defined as a sum of kernels:
-
-```math
-  k(x, x'; \{k_i\}) = \sum_i k_i(x, x').
+```@docs
+TransformedKernel
+transform(::Kernel, ::Transform)
+transform(::Kernel, ::Real)
+transform(::Kernel, ::AbstractVector{<:Real})
+ScaledKernel
+KernelSum
+KernelProduct
+TensorProduct
 ```
 
-### Kernel Product
+# Multi-output Kernels
 
-The [`KernelProduct`](@ref) is defined as a product of kernels:
-
-```math
-  k(x,x';\{k_i\}) = \prod_i k_i(x,x').
-```
-
-### Tensor Product
-
-The [`TensorProduct`](@ref) is defined as:
-
-```math
-  k(x,x';\{k_i\}) = \prod_i k_i(x_i,x'_i)
+```@docs
+MOKernel
+IndependentMOKernel
+LatentFactorMOKernel
 ```

--- a/docs/src/kernels.md
+++ b/docs/src/kernels.md
@@ -110,10 +110,11 @@ WienerKernel
 
 ## Composite Kernels
 
-The modular design of KernelFunctions.jl uses [base kernels](@ref base_kernels) as building
-blocks for more complex kernels. These composite kernels can be created by adding
-[input transforms](@ref input_transforms) such as scaling the inputs with an inverse
-lengthscale, by scaling the variance of a kernel, or by summing or multiplying different kernels.
+The modular design of KernelFunctions uses [base kernels](@ref base_kernels) as building
+blocks for more complex kernels. There are a variety of composite kernels implemented,
+including those which [transform the inputs](@ref input_transforms) to a wrapped kernel
+to implement length scales, scale the variance of a kernel, and sum or multiply collections
+of kernels together.
 
 ```@docs
 TransformedKernel

--- a/docs/src/kernels.md
+++ b/docs/src/kernels.md
@@ -4,12 +4,7 @@
 
 # Kernel Functions
 
-```@contents
-Pages = ["kernels.md"]
-Depth = 3
-```
-
-## Base Kernels
+## [Base Kernels](@id base_kernels)
 
 These are the basic kernels without any transformation of the data. They are the building blocks of KernelFunctions.
 
@@ -115,10 +110,10 @@ WienerKernel
 
 ## Composite Kernels
 
-The modular design of KernelFunctions.jl uses [base kernels](@ref) as building blocks for
-more complex kernels. These composite kernels can be created by adding
-[input transforms](@ref) such as scaling the inputs with an inverse lengthscale, by scaling the
-variance of a kernel, or by summing or multiplying different kernels.
+The modular design of KernelFunctions.jl uses [base kernels](@ref base_kernels) as building
+blocks for more complex kernels. These composite kernels can be created by adding
+[input transforms](@ref input_transforms) such as scaling the inputs with an inverse
+lengthscale, by scaling the variance of a kernel, or by summing or multiplying different kernels.
 
 ```@docs
 TransformedKernel

--- a/docs/src/transform.md
+++ b/docs/src/transform.md
@@ -1,6 +1,6 @@
 # Input Transforms
 
-[`Transform`](@ref) is the object that takes care of transforming the input data before distances are being computed.
+[`Transform`](@ref)s are designed to change input data before passing it on to a kernel object.
 
 It can be as standard as [`IdentityTransform`](@ref) returning the same input, or
 multiplying the data by a scalar with [`ScaleTransform`](@ref) or by a vector with
@@ -13,7 +13,13 @@ You can also create a pipeline of [`Transform`](@ref)s via [`ChainTransform`](@r
 LowRankTransform(rand(10, 5)) ∘ ScaleTransform(2.0)
 ```
 
-A transformation `t` can be applied to a vector `v` with `map`.
+
+A transformation `t` can be applied to a single input `x` with `t(x)` and to multiple inputs
+`xs` with `map(t, xs)`.
+
+Kernels can be coupled with input transformations with
+[`transform`](@ref). It falls back to creating a [`TransformedKernel`](@ref) but allows more
+optimized implementations for specific kernels and transformations.
 
 ## List of Input Transforms
 

--- a/docs/src/transform.md
+++ b/docs/src/transform.md
@@ -1,4 +1,6 @@
-# Input Transforms
+# [Input Transforms](@id input_transforms)
+
+## Overview
 
 [`Transform`](@ref)s are designed to change input data before passing it on to a kernel object.
 
@@ -12,7 +14,6 @@ You can also create a pipeline of [`Transform`](@ref)s via [`ChainTransform`](@r
 ```julia
 LowRankTransform(rand(10, 5)) ∘ ScaleTransform(2.0)
 ```
-
 
 A transformation `t` can be applied to a single input `x` with `t(x)` and to multiple inputs
 `xs` with `map(t, xs)`.

--- a/docs/src/transform.md
+++ b/docs/src/transform.md
@@ -1,9 +1,31 @@
 # Input Transforms
 
-`Transform` is the object that takes care of transforming the input data before distances are being computed. It can be as standard as `IdentityTransform` returning the same input, or multiplying the data by a scalar with `ScaleTransform` or by a vector with `ARDTransform`.
-There is a more general `Transform`: `FunctionTransform` that uses a function and applies it on each vector via `mapslices`.
-You can also create a pipeline of `Transform` via `TransformChain`. For example, `LowRankTransform(rand(10,5))∘ScaleTransform(2.0)`.
+[`Transform`](@ref) is the object that takes care of transforming the input data before distances are being computed.
 
-A transformation `t` can be applied to a matrix or a vector `v` via `KernelFunctions.apply(t, v)`.
+It can be as standard as [`IdentityTransform`](@ref) returning the same input, or
+multiplying the data by a scalar with [`ScaleTransform`](@ref) or by a vector with
+[`ARDTransform`](@ref).
+There is a more general [`FunctionTransform`](@ref) that uses a function and applies it to
+each input.
 
-Check the full list of provided transforms on the [API page](@ref Transforms).
+You can also create a pipeline of [`Transform`](@ref)s via [`ChainTransform`](@ref), e.g.,
+```julia
+LowRankTransform(rand(10, 5)) ∘ ScaleTransform(2.0)
+```
+
+A transformation `t` can be applied to a vector `v` with `map`.
+
+## List of Input Transforms
+
+```@docs
+Transform
+IdentityTransform
+ScaleTransform
+ARDTransform
+ARDTransform(::Real, ::Integer)
+LinearTransform
+FunctionTransform
+SelectTransform
+ChainTransform
+PeriodicTransform
+```

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -2,7 +2,7 @@
 
 ## Kernel creation
 
-To create a kernel object, choose one of the pre-implemented kernels, see [Base Kernels](@ref), or create your own, see [Creating your own kernel](@ref).
+To create a kernel object, choose one of the pre-implemented kernels, see [Kernel Functions](@ref), or create your own, see [Creating your own kernel](@ref).
 For example, a squared exponential kernel is created by
 ```julia
   k = SqExponentialKernel()
@@ -15,7 +15,7 @@ For example, a squared exponential kernel is created by
       k = transform(SqExponentialKernel(), ScaleTransform(2.0))
       k = transform(SqExponentialKernel(), 2.0)  # implicitly constructs a ScaleTransform(2.0)
     ```
-    Check the [Input Transforms](@ref) page for more details.
+    Check the [Input Transforms](@ref input_transforms) page for more details.
 
 !!! tip "How do I set the kernel variance?"
     To premultiply the kernel by a variance, you can use `*` with a scalar number:

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -15,7 +15,7 @@ For example, a squared exponential kernel is created by
       k = transform(SqExponentialKernel(), ScaleTransform(2.0))
       k = transform(SqExponentialKernel(), 2.0)  # implicitly constructs a ScaleTransform(2.0)
     ```
-    Check the [Input Transforms](@ref) page for more details. The API documentation contains an [overview of all available transforms](@ref Transforms).
+    Check the [Input Transforms](@ref) page for more details.
 
 !!! tip "How do I set the kernel variance?"
     To premultiply the kernel by a variance, you can use `*` with a scalar number:

--- a/src/basekernels/cosine.jl
+++ b/src/basekernels/cosine.jl
@@ -1,14 +1,18 @@
 """
     CosineKernel()
 
-The cosine kernel is a stationary kernel for a sinusoidal given by
-```
-    κ(x,y) = cos( π * (x-y) )
+Cosine kernel.
+
+# Definition
+
+For inputs ``x, x' \\in \\mathbb{R}^d``, the cosine kernel is defined as
+```math
+k(x, x') = \\cos(\\pi \\|x-x'\\|_2).
 ```
 """
 struct CosineKernel <: SimpleKernel end
 
-kappa(κ::CosineKernel, d::Real) = cospi(d)
+kappa(::CosineKernel, d::Real) = cospi(d)
 
 metric(::CosineKernel) = Euclidean()
 

--- a/src/basekernels/exponential.jl
+++ b/src/basekernels/exponential.jl
@@ -1,16 +1,20 @@
 """
     SqExponentialKernel()
 
-The squared exponential kernel is a Mercer kernel given by the formula:
+Squared exponential kernel.
+
+# Definition
+
+For inputs ``x, x' \\in \\mathbb{R}^d``, the squared exponential kernel is defined as
+```math
+k(x, x') = \\exp\\bigg(- \\frac{\\|x - x'\\|_2^2}{2}\\bigg).
 ```
-    κ(x, y) = exp(-‖x - y‖² / 2)
-```
-Can also be called via `RBFKernel`, `GaussianKernel` or `SEKernel`.
-See [`GammaExponentialKernel`](@ref) for a generalization.
+
+See also: [`GammaExponentialKernel`](@ref)
 """
 struct SqExponentialKernel <: SimpleKernel end
 
-kappa(κ::SqExponentialKernel, d²::Real) = exp(-d² / 2)
+kappa(::SqExponentialKernel, d²::Real) = exp(-d² / 2)
 
 metric(::SqExponentialKernel) = SqEuclidean()
 
@@ -23,37 +27,41 @@ Base.show(io::IO, ::SqExponentialKernel) = print(io, "Squared Exponential Kernel
 """
     RBFKernel()
 
-See [`SqExponentialKernel`](@ref)
+Alias of [`SqExponentialKernel`](@ref).
 """
 const RBFKernel = SqExponentialKernel
 
 """
     GaussianKernel()
 
-See [`SqExponentialKernel`](@ref)
+Alias of [`SqExponentialKernel`](@ref).
 """
 const GaussianKernel = SqExponentialKernel
 
 """
     SEKernel()
 
-See [`SqExponentialKernel`](@ref)
+Alias of [`SqExponentialKernel`](@ref).
 """
 const SEKernel = SqExponentialKernel
 
 """
     ExponentialKernel()
 
-The exponential kernel is a Mercer kernel given by the formula:
+Exponential kernel.
+
+# Definition
+
+For inputs ``x, x' \\in \\mathbb{R}^d``, the exponential kernel is defined as
+```math
+k(x, x') = \\exp\\big(- \\|x - x'\\|_2\\big).
 ```
-    κ(x,y) = exp(-‖x-y‖)
-```
-Can also be called via `LaplacianKernel` or `Matern12Kernel`.
-See [`GammaExponentialKernel`](@ref) for a generalization.
+
+See also: [`GammaExponentialKernel`](@ref)
 """
 struct ExponentialKernel <: SimpleKernel end
 
-kappa(κ::ExponentialKernel, d::Real) = exp(-d)
+kappa(::ExponentialKernel, d::Real) = exp(-d)
 
 metric(::ExponentialKernel) = Euclidean()
 
@@ -66,35 +74,39 @@ Base.show(io::IO, ::ExponentialKernel) = print(io, "Exponential Kernel")
 """
     LaplacianKernel()
 
-See [`ExponentialKernel`](@ref)
+Alias of [`ExponentialKernel`](@ref).
 """
 const LaplacianKernel = ExponentialKernel
 
 """
     Matern12Kernel()
 
-See [`ExponentialKernel`](@ref)
+Alias of [`ExponentialKernel`](@ref).
 """
 const Matern12Kernel = ExponentialKernel
 
 """
-    GammaExponentialKernel(; γ = 2.0)
+    GammaExponentialKernel(; γ::Real=2.0)
 
-The γ-exponential kernel [1] is an isotropic Mercer kernel given by the formula:
-```
-    κ(x,y) = exp(-‖x-y‖^γ)
-```
-Where `γ > 0`, (the keyword `γ` can be replaced by `gamma`)
-For `γ = 2`, see [`SqExponentialKernel`](@ref); for `γ = 1`, see [`ExponentialKernel`](@ref).
+γ-exponential kernel with parameter `γ`.
 
-[1] - Gaussian Processes for Machine Learning, Carl Edward Rasmussen and Christopher K. I.
-    Williams, MIT Press, 2006.
+# Definition
+
+For inputs ``x, x' \\in \\mathbb{R}^d``, the γ-exponential kernel[^RW] with parameter
+``\\gamma \\in (0, 2]`` is defined as
+```math
+k(x, x'; \\gamma) = \\exp\\big(- \\|x - x'\\|_2^{\\gamma}\\big).
+```
+
+See also: [`ExponentialKernel`](@ref), [`SqExponentialKernel`](@ref)
+
+[^RW]: C. E. Rasmussen & C. K. I. Williams (2006). Gaussian Processes for Machine Learning.
 """
 struct GammaExponentialKernel{Tγ<:Real} <: SimpleKernel
     γ::Vector{Tγ}
-    function GammaExponentialKernel(; gamma::T=2.0, γ::T=gamma) where {T<:Real}
-        @check_args(GammaExponentialKernel, γ, γ >= zero(T), "γ > 0")
-        return new{T}([γ])
+    function GammaExponentialKernel(; gamma::Real=2.0, γ::Real=gamma)
+        @check_args(GammaExponentialKernel, γ, zero(γ) < γ ≤ 2 * one(γ), "γ ∈ (0, 2]")
+        return new{typeof(γ)}([γ])
     end
 end
 

--- a/src/basekernels/exponential.jl
+++ b/src/basekernels/exponential.jl
@@ -105,7 +105,7 @@ See also: [`ExponentialKernel`](@ref), [`SqExponentialKernel`](@ref)
 struct GammaExponentialKernel{Tγ<:Real} <: SimpleKernel
     γ::Vector{Tγ}
     function GammaExponentialKernel(; gamma::Real=2.0, γ::Real=gamma)
-        @check_args(GammaExponentialKernel, γ, zero(γ) < γ ≤ 2 * one(γ), "γ ∈ (0, 2]")
+        @check_args(GammaExponentialKernel, γ, zero(γ) < γ ≤ 2, "γ ∈ (0, 2]")
         return new{typeof(γ)}([γ])
     end
 end

--- a/src/basekernels/exponentiated.jl
+++ b/src/basekernels/exponentiated.jl
@@ -1,14 +1,18 @@
 """
     ExponentiatedKernel()
 
-The exponentiated kernel is a Mercer kernel given by:
-```
-    κ(x,y) = exp(xᵀy)
+Exponentiated kernel.
+
+# Definition
+
+For inputs ``x, x' \\in \\mathbb{R}^d``, the exponentiated kernel is defined as
+```math
+k(x, x') = \\exp(x^\\top x').
 ```
 """
 struct ExponentiatedKernel <: SimpleKernel end
 
-kappa(κ::ExponentiatedKernel, xᵀy::Real) = exp(xᵀy)
+kappa(::ExponentiatedKernel, xᵀy::Real) = exp(xᵀy)
 
 metric(::ExponentiatedKernel) = DotProduct()
 

--- a/src/basekernels/fbm.jl
+++ b/src/basekernels/fbm.jl
@@ -1,19 +1,22 @@
 """
     FBMKernel(; h::Real=0.5)
 
-Fractional Brownian motion kernel with Hurst index `h` from (0,1) given by
-```
-    κ(x,y) =  ( |x|²ʰ + |y|²ʰ - |x-y|²ʰ ) / 2
-```
+Fractional Brownian motion kernel with Hurst index `h`.
 
-For `h=1/2`, this is the Wiener Kernel, for `h>1/2`, the increments are
-positively correlated and for `h<1/2` the increments are negatively correlated.
+# Definition
+
+For inputs ``x, x' \\in \\mathbb{R}^d``, the fractional Brownian motion kernel with
+[Hurst index](https://en.wikipedia.org/wiki/Hurst_exponent#Generalized_exponent)
+``h \\in [0,1]`` is defined as
+```math
+k(x, x'; h) =  \\frac{\\|x\\|_2^{2h} + \\|x'\\|_2^{2h} - \\|x - x'\\|^{2h}}{2}.
+```
 """
 struct FBMKernel{T<:Real} <: Kernel
     h::Vector{T}
-    function FBMKernel(; h::T=0.5) where {T<:Real}
-        @assert 0.0 <= h <= 1.0 "FBMKernel: Given Hurst index h is invalid."
-        return new{T}([h])
+    function FBMKernel(; h::Real=0.5)
+        @check_args(FBMKernel, h, zero(h) ≤ h ≤ one(h), "h ∈ [0, 1]")
+        return new{typeof(h)}([h])
     end
 end
 

--- a/src/basekernels/gabor.jl
+++ b/src/basekernels/gabor.jl
@@ -1,11 +1,16 @@
 """
     GaborKernel(; ell::Real=1.0, p::Real=1.0)
 
-Gabor kernel with lengthscale `ell` and period `p`. Given by
-```math
-    κ(x,y) =  h(x-z), h(t) = exp(-sum(t.^2./(ell.^2)))*cos(pi*sum(t./p))
-```
+Gabor kernel with lengthscale `ell` and period `p`.
 
+# Definition
+
+For inputs ``x, x' \\in \\mathbb{R}^d``, the Gabor kernel with lengthscale ``l_i > 0``
+and period ``p_i > 0`` is defined as
+```math
+k(x, x'; l, p) = \\exp\\bigg(- \\cos\\bigg(\\pi\\sum_{i=1}^d \\frac{x_i - x'_i}{p_i}\\bigg)
+                             \\sum_{i=1}^d \\frac{(x_i - x'_i)^2}{l_i^2}\\bigg).
+```
 """
 struct GaborKernel{K<:Kernel} <: Kernel
     kernel::K

--- a/src/basekernels/matern.jl
+++ b/src/basekernels/matern.jl
@@ -1,19 +1,28 @@
 """
-    MaternKernel(; ν = 1.0)
+    MaternKernel(; ν::Real=1.5)
 
-The matern kernel is a Mercer kernel given by the formula:
+Matérn kernel of order `ν`.
+
+# Definition
+
+For inputs ``x, x' \\in \\mathbb{R}^d``, the Matérn kernel of order ``\\nu > 0`` is
+defined as
+```math
+k(x,x';\\nu) = \\frac{2^{1-\\nu}}{\\Gamma(\\nu)}\\big(\\sqrt{2\\nu}\\|x-x'\\|_2\\big) K_\\nu\\big(\\sqrt{2\\nu}\\|x-x'\\|_2\\big),
 ```
-    κ(x,y) = 2^{1-ν}/Γ(ν)*(√(2ν)‖x-y‖)^ν K_ν(√(2ν)‖x-y‖)
-```
-For `ν=n+1/2, n=0,1,2,...` it can be simplified and you should instead use 
-[`ExponentialKernel`](@ref) for `n=0`, [`Matern32Kernel`](@ref), for `n=1`, 
-[`Matern52Kernel`](@ref) for `n=2` and [`SqExponentialKernel`](@ref) for `n=∞`.
+where ``\\Gamma`` is the Gamma function and ``K_{\\nu}`` is the modified Bessel function of
+the second kind of order ``\\nu``.
+
+A Gaussian process with a Matérn kernel is ``\\lceil \\nu \\rceil - 1``-times
+differentiable in the mean-square sense.
+
+See also: [`Matern12Kernel`](@ref), [`Matern32Kernel`](@ref), [`Matern52Kernel`](@ref)
 """
 struct MaternKernel{Tν<:Real} <: SimpleKernel
     ν::Vector{Tν}
-    function MaternKernel(; nu::T=1.5, ν::T=nu) where {T<:Real}
-        @check_args(MaternKernel, ν, ν > zero(T), "ν > 0")
-        return new{T}([ν])
+    function MaternKernel(; nu::Real=1.5, ν::Real=nu)
+        @check_args(MaternKernel, ν, ν > zero(ν), "ν > 0")
+        return new{typeof(ν)}([ν])
     end
 end
 
@@ -38,14 +47,20 @@ Base.show(io::IO, κ::MaternKernel) = print(io, "Matern Kernel (ν = ", first(κ
 """
     Matern32Kernel()
 
-The matern 3/2 kernel is a Mercer kernel given by the formula:
+Matérn kernel of order ``3/2``.
+
+# Definition
+
+For inputs ``x, x' \\in \\mathbb{R}^d``, the Matérn kernel of order ``3/2`` is given by
+```math
+k(x, x') = \\big(1 + \\sqrt{3} \\|x - x'\\|_2 \\big) \\exp\\big(- \\sqrt{3}\\|x - x'\\|_2\\big).
 ```
-    κ(x,y) = (1+√(3)‖x-y‖)exp(-√(3)‖x-y‖)
-```
+
+See also: [`MaternKernel`](@ref)
 """
 struct Matern32Kernel <: SimpleKernel end
 
-kappa(κ::Matern32Kernel, d::Real) = (1 + sqrt(3) * d) * exp(-sqrt(3) * d)
+kappa(::Matern32Kernel, d::Real) = (1 + sqrt(3) * d) * exp(-sqrt(3) * d)
 
 metric(::Matern32Kernel) = Euclidean()
 
@@ -54,14 +69,21 @@ Base.show(io::IO, ::Matern32Kernel) = print(io, "Matern 3/2 Kernel")
 """
     Matern52Kernel()
 
-The matern 5/2 kernel is a Mercer kernel given by the formula:
+Matérn kernel of order ``5/2``.
+
+# Definition
+
+For inputs ``x, x' \\in \\mathbb{R}^d``, the Matérn kernel of order ``5/2`` is given by
+```math
+k(x, x') = \\bigg(1 + \\sqrt{5} \\|x - x'\\|_2 + \\frac{5}{3}\\|x - x'\\|_2^2\\bigg)
+           \\exp\\big(- \\sqrt{5}\\|x - x'\\|_2\\big).
 ```
-    κ(x,y) = (1+√(5)‖x-y‖ + 5/3‖x-y‖^2)exp(-√(5)‖x-y‖)
-```
+
+See also: [`MaternKernel`](@ref)
 """
 struct Matern52Kernel <: SimpleKernel end
 
-kappa(κ::Matern52Kernel, d::Real) = (1 + sqrt(5) * d + 5 * d^2 / 3) * exp(-sqrt(5) * d)
+kappa(::Matern52Kernel, d::Real) = (1 + sqrt(5) * d + 5 * d^2 / 3) * exp(-sqrt(5) * d)
 
 metric(::Matern52Kernel) = Euclidean()
 

--- a/src/basekernels/nn.jl
+++ b/src/basekernels/nn.jl
@@ -1,21 +1,35 @@
 """
     NeuralNetworkKernel()
 
-Neural network kernel function.
+Kernel of a Gaussian process obtained as the limit of a Bayesian neural network with a
+single hidden layer as the number of units goes to infinity.
 
+# Definition
+
+Consider the single-layer Bayesian neural network
+``f \\colon \\mathbb{R}^d \\to \\mathbb{R}`` with ``h`` hidden units defined by
 ```math
-    κ(x, y) =  asin(x' * y / sqrt[(1 + x' * x) * (1 + y' * y)])
+f(x; b, v, u) = b + \\sqrt{\\frac{\\pi}{2}} \\sum_{i=1}^{h} v_i \\mathrm{erf}\\big(u_i^\\top x\\big),
 ```
-# Significance
-Neal (1996) pursued the limits of large models, and showed that a Bayesian neural network
-becomes a Gaussian process with a **neural network kernel** as the number of units
-approaches infinity. Here, we give the neural network kernel for single hidden layer
-Bayesian neural network with erf (Error Function) as activation function.
+where ``\\mathrm{erf}`` is the error function, and with prior distributions
+```math
+\\begin{aligned}
+b &\\sim \\mathcal{N}(0, \\sigma_b^2),\\\\
+v &\\sim \\mathcal{N}(0, \\sigma_v^2 \\mathrm{I}_{h}/h),\\\\
+u_i &\\sim \\mathcal{N}(0, \\mathrm{I}_{d}/2) \\qquad (i = 1,\\ldots,h).
+\\end{aligned}
+```
+As ``h \\to \\infty``, the neural network converges to the Gaussian process
+```math
+g(\\cdot) \\sim \\mathcal{GP}\\big(0, \\sigma_b^2 + \\sigma_v^2 k(\\cdot, \\cdot)\\big),
+```
+where the neural network kernel ``k`` is given by
+```math
+k(x, x') = \\arcsin\\left(\\frac{x^\\top x'}{\\sqrt{\\big(1 + \\|x\\|^2_2\\big) \\big(1 + \\|x'\\|_2^2\\big)}}\\right)
+```
+for inputs ``x, x' \\in \\mathbb{R}^d``.[^CW]
 
-# References:
-- [GPML Pg 105](http://www.gaussianprocess.org/gpml/chapters/RW4.pdf)
-- [Neal(1996)](https://www.cs.toronto.edu/~radford/bnn.book.html)
-- [Andrew Gordon's Thesis Pg 45](http://www.cs.cmu.edu/~andrewgw/andrewgwthesis.pdf)
+[^CW]: C. K. I. Williams (1998). Computation with infinite neural networks.
 """
 struct NeuralNetworkKernel <: Kernel end
 
@@ -51,4 +65,4 @@ function kernelmatrix(::NeuralNetworkKernel, x::RowVecs)
     return asin.(XX ./ sqrt.(X_2_1 * X_2_1'))
 end
 
-Base.show(io::IO, κ::NeuralNetworkKernel) = print(io, "Neural Network Kernel")
+Base.show(io::IO, ::NeuralNetworkKernel) = print(io, "Neural Network Kernel")

--- a/src/basekernels/periodic.jl
+++ b/src/basekernels/periodic.jl
@@ -5,7 +5,7 @@ Periodic kernel with parameter `r`.
 
 # Definition
 
-For inputs ``x, x' \\in \\mathbb{R}^d``, the period kernel with parameter ``r_i > 0`` is
+For inputs ``x, x' \\in \\mathbb{R}^d``, the periodic kernel with parameter ``r_i > 0`` is
 defined[^DM] as
 ```math
 k(x, x'; r) = \\exp\\bigg(- \\frac{1}{2} \\sum_{i=1}^d \\bigg(\\frac{\\sin\\big(\\pi(x_i - x'_i)\\big)}{r_i}\\bigg)^2\\bigg).

--- a/src/basekernels/periodic.jl
+++ b/src/basekernels/periodic.jl
@@ -1,30 +1,40 @@
 """
-    PeriodicKernel(r::AbstractVector)
-    PeriodicKernel(dims::Int)
-    PeriodicKernel(T::DataType, dims::Int)
+    PeriodicKernel(; r::AbstractVector=ones(Float64, 1))
 
-Periodic Kernel as described in http://www.inference.org.uk/mackay/gpB.pdf eq. 47.
+Periodic kernel with parameter `r`.
+
+# Definition
+
+For inputs ``x, x' \\in \\mathbb{R}^d``, the period kernel with parameter ``r_i > 0`` is
+defined[^DM] as
+```math
+k(x, x'; r) = \\exp\\bigg(- \\frac{1}{2} \\sum_{i=1}^d \\bigg(\\frac{\\sin\\big(\\pi(x_i - x'_i)\\big)}{r_i}\\bigg)^2\\bigg).
 ```
-    κ(x,y) = exp( - 0.5 sum_i(sin (π(x_i - y_i))/r_i))
-```
+
+[^DM]: D. J. C. MacKay (1998). Introduction to Gaussian Processes.
 """
 struct PeriodicKernel{T} <: SimpleKernel
     r::Vector{T}
-    function PeriodicKernel(; r::AbstractVector{T}=ones(Float64, 1)) where {T<:Real}
-        @assert all(r .> 0)
-        return new{T}(r)
+    function PeriodicKernel(; r::AbstractVector{<:Real}=ones(Float64, 1))
+        @check_args(PeriodicKernel, r, all(ri > zero(ri) for ri in r), "r > 0")
+        return new{eltype(r)}(r)
     end
 end
 
 PeriodicKernel(dims::Int) = PeriodicKernel(Float64, dims)
 
+"""
+    PeriodicKernel([T=Float64, dims::Int=1])
+
+Create a [`PeriodicKernel`](@ref) with parameter `r=ones(T, dims)`.
+"""
 PeriodicKernel(T::DataType, dims::Int=1) = PeriodicKernel(; r=ones(T, dims))
 
 @functor PeriodicKernel
 
 metric(κ::PeriodicKernel) = Sinus(κ.r)
 
-kappa(κ::PeriodicKernel, d::Real) = exp(-0.5d)
+kappa(::PeriodicKernel, d::Real) = exp(-0.5d)
 
 function Base.show(io::IO, κ::PeriodicKernel)
     return print(io, "Periodic Kernel, length(r) = $(length(κ.r))")

--- a/src/basekernels/rationalquad.jl
+++ b/src/basekernels/rationalquad.jl
@@ -1,12 +1,17 @@
 """
-    RationalQuadraticKernel(; α=2.0)
+    RationalQuadraticKernel(; α::Real=2.0)
 
-The rational-quadratic kernel is a Mercer kernel given by the formula:
+Rational-quadratic kernel with shape parameter `α`.
+
+# Definition
+
+For inputs ``x, x' \\in \\mathbb{R}^d``, the rational-quadratic kernel with shape parameter
+``\\alpha > 0`` is defined as
+```math
+k(x, x'; \\alpha) = \\bigg(1 + \\frac{\\|x - x'\\|_2^2}{2\\alpha}\\right)^{-\\alpha}.
 ```
-    κ(x, y) = (1 + ||x − y||² / (2α))^(-α)
-```
-where `α` is a shape parameter of the Euclidean distance. Check
-[`GammaRationalQuadraticKernel`](@ref) for a generalization.
+
+See also: [`GammaRationalQuadraticKernel`](@ref)
 """
 struct RationalQuadraticKernel{Tα<:Real} <: SimpleKernel
     α::Vector{Tα}
@@ -29,13 +34,19 @@ function Base.show(io::IO, κ::RationalQuadraticKernel)
 end
 
 """
-`GammaRationalQuadraticKernel([α=2.0 [, γ=2.0]])`
+    GammaRationalQuadraticKernel(; α::Real=2.0, γ::Real=2.0)
 
-The Gamma-rational-quadratic kernel is an isotropic Mercer kernel given by the formula:
+γ-rational-quadratic kernel with shape parameters `α` and `γ`.
+
+# Definition
+
+For inputs ``x, x' \\in \\mathbb{R}^d``, the γ-rational-quadratic kernel with shape
+parameters ``\\alpha > 0`` and ``\\gamma \\in (0, 2]`` is defined as
+```math
+k(x, x'; \\alpha, \\gamma) = \\bigg(1 + \\frac{\\|x - x'\\|_2^{\\gamma}}{2\\alpha}\\bigg)^{-\\alpha}.
 ```
-    κ(x, y) = (1 + ||x−y||^γ / α)^(-α)
-```
-where `α` is a shape parameter of the Euclidean distance and `γ` is another shape parameter.
+
+See also: [`RationalQuadraticKernel`](@ref)
 """
 struct GammaRationalQuadraticKernel{Tα<:Real,Tγ<:Real} <: SimpleKernel
     α::Vector{Tα}
@@ -44,18 +55,18 @@ struct GammaRationalQuadraticKernel{Tα<:Real,Tγ<:Real} <: SimpleKernel
         alpha::Tα=2.0, gamma::Tγ=2.0, α::Tα=alpha, γ::Tγ=gamma
     ) where {Tα<:Real,Tγ<:Real}
         @check_args(GammaRationalQuadraticKernel, α, α > zero(Tα), "α > 0")
-        @check_args(GammaRationalQuadraticKernel, γ, zero(γ) < γ <= 2, "0 < γ <= 2")
+        @check_args(GammaRationalQuadraticKernel, γ, zero(γ) < γ <= 2, "γ ∈ (0, 2]")
         return new{Tα,Tγ}([α], [γ])
     end
 end
 
 @functor GammaRationalQuadraticKernel
 
-function kappa(κ::GammaRationalQuadraticKernel, d²::Real)
-    return (one(d²) + d²^(first(κ.γ) / 2) / first(κ.α))^(-first(κ.α))
+function kappa(κ::GammaRationalQuadraticKernel, d::Real)
+    return (one(d) + d^first(κ.γ) / (2 * first(κ.α)))^(-first(κ.α))
 end
 
-metric(::GammaRationalQuadraticKernel) = SqEuclidean()
+metric(::GammaRationalQuadraticKernel) = Euclidean()
 
 function Base.show(io::IO, κ::GammaRationalQuadraticKernel)
     return print(

--- a/src/basekernels/rationalquad.jl
+++ b/src/basekernels/rationalquad.jl
@@ -52,11 +52,11 @@ struct GammaRationalQuadraticKernel{Tα<:Real,Tγ<:Real} <: SimpleKernel
     α::Vector{Tα}
     γ::Vector{Tγ}
     function GammaRationalQuadraticKernel(;
-        alpha::Tα=2.0, gamma::Tγ=2.0, α::Tα=alpha, γ::Tγ=gamma
-    ) where {Tα<:Real,Tγ<:Real}
-        @check_args(GammaRationalQuadraticKernel, α, α > zero(Tα), "α > 0")
-        @check_args(GammaRationalQuadraticKernel, γ, zero(γ) < γ <= 2, "γ ∈ (0, 2]")
-        return new{Tα,Tγ}([α], [γ])
+        alpha::Real=2.0, gamma::Real=2.0, α::Real=alpha, γ::Real=gamma
+    )
+        @check_args(GammaRationalQuadraticKernel, α, α > zero(α), "α > 0")
+        @check_args(GammaRationalQuadraticKernel, γ, zero(γ) < γ ≤ 2, "γ ∈ (0, 2]")
+        return new{typeof(α),typeof(γ)}([α], [γ])
     end
 end
 

--- a/src/basekernels/rationalquad.jl
+++ b/src/basekernels/rationalquad.jl
@@ -11,6 +11,8 @@ For inputs ``x, x' \\in \\mathbb{R}^d``, the rational-quadratic kernel with shap
 k(x, x'; \\alpha) = \\bigg(1 + \\frac{\\|x - x'\\|_2^2}{2\\alpha}\\bigg)^{-\\alpha}.
 ```
 
+The [`SqExponentialKernel`](@ref) is recovered in the limit as ``\\alpha \\to \\infty``.
+
 See also: [`GammaRationalQuadraticKernel`](@ref)
 """
 struct RationalQuadraticKernel{Tα<:Real} <: SimpleKernel
@@ -43,8 +45,10 @@ end
 For inputs ``x, x' \\in \\mathbb{R}^d``, the γ-rational-quadratic kernel with shape
 parameters ``\\alpha > 0`` and ``\\gamma \\in (0, 2]`` is defined as
 ```math
-k(x, x'; \\alpha, \\gamma) = \\bigg(1 + \\frac{\\|x - x'\\|_2^{\\gamma}}{2\\alpha}\\bigg)^{-\\alpha}.
+k(x, x'; \\alpha, \\gamma) = \\bigg(1 + \\frac{\\|x - x'\\|_2^{\\gamma}}{\\alpha}\\bigg)^{-\\alpha}.
 ```
+
+The [`GammaExponentialKernel`](@ref) is recovered in the limit as ``\\alpha \\to \\infty``.
 
 See also: [`RationalQuadraticKernel`](@ref)
 """
@@ -63,7 +67,7 @@ end
 @functor GammaRationalQuadraticKernel
 
 function kappa(κ::GammaRationalQuadraticKernel, d::Real)
-    return (one(d) + d^first(κ.γ) / (2 * first(κ.α)))^(-first(κ.α))
+    return (one(d) + d^first(κ.γ) / first(κ.α))^(-first(κ.α))
 end
 
 metric(::GammaRationalQuadraticKernel) = Euclidean()

--- a/src/basekernels/rationalquad.jl
+++ b/src/basekernels/rationalquad.jl
@@ -8,7 +8,7 @@ Rational-quadratic kernel with shape parameter `α`.
 For inputs ``x, x' \\in \\mathbb{R}^d``, the rational-quadratic kernel with shape parameter
 ``\\alpha > 0`` is defined as
 ```math
-k(x, x'; \\alpha) = \\bigg(1 + \\frac{\\|x - x'\\|_2^2}{2\\alpha}\\right)^{-\\alpha}.
+k(x, x'; \\alpha) = \\bigg(1 + \\frac{\\|x - x'\\|_2^2}{2\\alpha}\\bigg)^{-\\alpha}.
 ```
 
 See also: [`GammaRationalQuadraticKernel`](@ref)

--- a/src/basekernels/wiener.jl
+++ b/src/basekernels/wiener.jl
@@ -1,7 +1,10 @@
 """
+    WienerKernel(; i::Int=0)
     WienerKernel{i}()
 
-i-times integrated Wiener process kernel function.
+An `i`-times integrated Wiener process kernel function.
+
+# Definition
 
 - For i=-1, this is just the white noise covariance, see [`WhiteKernel`](@ref).
 - For i= 0, this is the Wiener process covariance,
@@ -31,10 +34,11 @@ and for ``i >= 1``,
 See the paper *Probabilistic ODE Solvers with Runge-Kutta Means* by Schober, Duvenaud and
 Hennig, NIPS, 2014, for more details.
 
+See also: [`WhiteKernel`](@ref)
 """
 struct WienerKernel{I} <: Kernel
     function WienerKernel{I}() where {I}
-        @assert I ∈ (-1, 0, 1, 2, 3) "Invalid parameter i=$(I). Should be -1, 0, 1, 2 or 3."
+        @check_args(WienerKernel, I, I ∈ (-1, 0, 1, 2, 3), "I ∈ {-1, 0, 1, 2, 3}")
         if I == -1
             return WhiteKernel()
         end

--- a/src/basekernels/wiener.jl
+++ b/src/basekernels/wiener.jl
@@ -34,7 +34,7 @@ r_3(t, t') &= 5 \\max(t, t')^2 + 2 tt' + 3 \\min(t, t')^2.
 \\end{aligned}
 ```
 
-For ``i = -1``, one recovers the the [`WhiteKernel`](@ref).
+The [`WhiteKernel`](@ref) is recovered for ``i = -1``.
 
 [^SDH]: Schober, Duvenaud & Hennig (2014). Probabilistic ODE Solvers with Runge-Kutta Means.
 """

--- a/src/basekernels/wiener.jl
+++ b/src/basekernels/wiener.jl
@@ -2,39 +2,41 @@
     WienerKernel(; i::Int=0)
     WienerKernel{i}()
 
-An `i`-times integrated Wiener process kernel function.
+The `i`-times integrated Wiener process kernel function.
 
 # Definition
 
-- For i=-1, this is just the white noise covariance, see [`WhiteKernel`](@ref).
-- For i= 0, this is the Wiener process covariance,
-- For i= 1, this is the integrated Wiener process covariance (velocity),
-- For i= 2, this is the twice-integrated Wiener process covariance (accel.),
-- For i= 3, this is the thrice-integrated Wiener process covariance,
-
-where ``κᵢ`` is given by
-
+For inputs ``x, x' \\in \\mathbb{R}^d``, the ``i``-times integrated Wiener process kernel
+with ``i \\in \\{-1, 0, 1, 2, 3\\}`` is defined[^SDH] as
 ```math
-    κ₋₁(x, y) =  δ(x, y)
-    κ₀(x, y)  =  min(x, y)
+k_i(x, x') = \\begin{cases}
+    \\delta(x, x') & \\text{if } i=-1,\\\\
+    \\min\\big(\\|x\\|_2, \\|x'\\|_2\\big) & \\text{if } i=0,\\\\
+    a_{i1}^{-1} \\min\\big(\\|x\\|_2, \\|x'\\|_2\\big)^{2i + 1}
+    + a_{i2}^{-1} \\|x - x'\\|_2 r_i\\big(\\|x\\|_2, \\|x'\\|_2\\big) \\min\\big(\\|x\\|_2, \\|x'\\|_2\\big)^{i + 1}
+    & \\text{otherwise},
+\\end{cases}
 ```
-and for ``i >= 1``,
+where the coefficients ``a`` are given by
 ```math
-    κᵢ(x, y) = 1 / aᵢ * min(x, y)^(2i + 1) + bᵢ * min(x, y)^(i + 1) * |x - y| * rᵢ(x, y),
+a = \\begin{bmatrix}
+3 & 2 \\\\
+20 & 12 \\\\
+252 & 720
+\\end{bmatrix}
 ```
-    with the coefficients ``aᵢ``, ``bᵢ`` and the residual ``rᵢ(x, y)`` defined as follows:
+and the functions ``r_i`` are defined as
 ```math
-    a₁ = 3, b₁ = 1/2, r₁(x, y) = 1,
-    a₂ = 20, b₂ = 1/12, r₂(x, y) = x + y - min(x, y) / 2,
-    a₃ = 252, b₃ = 1/720, r₃(x, y) = 5 * max(x, y)² + 2 * x * z + 3 * min(x, y)²
-
+\\begin{aligned}
+r_1(t, t') &= 1,\\\\
+r_2(t, t') &= t + t' - \\frac{\\min(t, t')}{2},\\\\
+r_3(t, t') &= 5 \\max(t, t')^2 + 2 tt' + 3 \\min(t, t')^2.
+\\end{aligned}
 ```
 
-# References:
-See the paper *Probabilistic ODE Solvers with Runge-Kutta Means* by Schober, Duvenaud and
-Hennig, NIPS, 2014, for more details.
+For ``i = -1``, one recovers the the [`WhiteKernel`](@ref).
 
-See also: [`WhiteKernel`](@ref)
+[^SDH]: Schober, Duvenaud & Hennig (2014). Probabilistic ODE Solvers with Runge-Kutta Means.
 """
 struct WienerKernel{I} <: Kernel
     function WienerKernel{I}() where {I}

--- a/src/kernels/scaledkernel.jl
+++ b/src/kernels/scaledkernel.jl
@@ -1,7 +1,15 @@
 """
-    ScaledKernel(k::Kernel, σ²::Real)
+    ScaledKernel(k::Kernel, σ²::Real=1.0)
 
-Return a kernel premultiplied by the variance `σ²` : `σ² k(x,x')`
+Scaled kernel derived from `k` by multiplication with variance `σ²`.
+
+# Definition
+
+For inputs ``x, x'``, the scaled kernel derived from kernel ``\\widetilde{k}`` by
+multiplication with variance ``\\sigma^2 > 0`` is defined as
+```math
+k(x, x'; \\sigma^2, \\widetilde{k}) = \\sigma^2 \\widetilde{k}(x, x').
+```
 """
 struct ScaledKernel{Tk<:Kernel,Tσ²<:Real} <: Kernel
     kernel::Tk

--- a/src/kernels/scaledkernel.jl
+++ b/src/kernels/scaledkernel.jl
@@ -5,10 +5,10 @@ Scaled kernel derived from `k` by multiplication with variance `σ²`.
 
 # Definition
 
-For inputs ``x, x'``, the scaled kernel derived from kernel ``\\widetilde{k}`` by
+For inputs ``x, x'``, the scaled kernel ``\\widetilde{k}`` derived from kernel ``k`` by
 multiplication with variance ``\\sigma^2 > 0`` is defined as
 ```math
-k(x, x'; \\sigma^2, \\widetilde{k}) = \\sigma^2 \\widetilde{k}(x, x').
+\\widetilde{k}(x, x'; k, \\sigma^2) = \\sigma^2 k(x, x').
 ```
 """
 struct ScaledKernel{Tk<:Kernel,Tσ²<:Real} <: Kernel

--- a/src/kernels/transformedkernel.jl
+++ b/src/kernels/transformedkernel.jl
@@ -1,8 +1,15 @@
 """
-    TransformedKernel(k::Kernel,t::Transform)
+    TransformedKernel(k::Kernel, t::Transform)
 
-Return a kernel where inputs are pretransformed by `t` : `k(t(x),t(x'))`
-Can also be called via [`transform`](@ref) : `transform(k, t)`
+Kernel derived from `k` for which inputs are transformed via a [`Transform`](@ref) `t`.
+
+# Definition
+
+For inputs ``x, x'``, the transformed kernel derived from kernel ``\\widetilde{k}`` by
+input transformation ``t`` is defined as
+```math
+k(x, x'; t, \\widetilde{k}) = \\widetilde{k}(t(x), t(x')).
+```
 """
 struct TransformedKernel{Tk<:Kernel,Tr<:Transform} <: Kernel
     kernel::Tk
@@ -31,25 +38,27 @@ end
 _scale(t::ScaleTransform, metric, x, y) = evaluate(metric, t(x), t(y))
 
 """
-```julia
-    transform(k::Kernel, t::Transform) (1)
-    transform(k::Kernel, ρ::Real) (2)
-    transform(k::Kernel, ρ::AbstractVector) (3)
-```
-(1) Create a TransformedKernel with transform `t` and kernel `k`
-(2) Same as (1) with a `ScaleTransform` with scale `ρ`
-(3) Same as (1) with an `ARDTransform` with scales `ρ`
+    transform(k::Kernel, t::Transform)
+
+Create a [`TransformedKernel`](@ref) for kernel `k` and transform `t`.
 """
-transform
-
 transform(k::Kernel, t::Transform) = TransformedKernel(k, t)
-
 function transform(k::TransformedKernel, t::Transform)
     return TransformedKernel(k.kernel, t ∘ k.transform)
 end
 
+"""
+    transform(k::Kernel, ρ::Real)
+
+Create a [`TransformedKernel`](@ref) for kernel `k` and inverse lengthscale `ρ`.
+"""
 transform(k::Kernel, ρ::Real) = transform(k, ScaleTransform(ρ))
 
+"""
+    transform(k::Kernel, ρ::AbstractVector)
+
+Create a [`TransformedKernel`](@ref) for kernel `k` and inverse lengthscales `ρ`.
+"""
 transform(k::Kernel, ρ::AbstractVector) = transform(k, ARDTransform(ρ))
 
 kernel(κ) = κ.kernel

--- a/src/kernels/transformedkernel.jl
+++ b/src/kernels/transformedkernel.jl
@@ -3,12 +3,16 @@
 
 Kernel derived from `k` for which inputs are transformed via a [`Transform`](@ref) `t`.
 
+It is preferred to create kernels with input transformations with [`transform`](@ref)
+instead of  `TransformedKernel` directly since [`transform`](@ref) allows optimized
+implementations for specific kernels and transformations.
+
 # Definition
 
-For inputs ``x, x'``, the transformed kernel derived from kernel ``\\widetilde{k}`` by
+For inputs ``x, x'``, the transformed kernel ``\\widetilde{k}`` derived from kernel ``k`` by
 input transformation ``t`` is defined as
 ```math
-k(x, x'; t, \\widetilde{k}) = \\widetilde{k}(t(x), t(x')).
+\\widetilde{k}(x, x'; k, t) = k\\big(t(x), t(x')\\big).
 ```
 """
 struct TransformedKernel{Tk<:Kernel,Tr<:Transform} <: Kernel

--- a/src/mokernels/independent.jl
+++ b/src/mokernels/independent.jl
@@ -1,23 +1,23 @@
 """
     IndependentMOKernel(k::Kernel)
 
-Kernel for multiple independent outputs with kernel `k`.
+Kernel for multiple independent outputs with kernel `k` each.
 
 # Definition
 
-For inputs ``x, x'`` and output dimensions ``p_x, p_{x'}'``, the kernel for independent
-outputs with kernel ``\\widetilde{k}`` is defined as
+For inputs ``x, x'`` and output dimensions ``p_x, p_{x'}'``, the kernel ``\\widetilde{k}``
+for independent outputs with kernel ``k`` each is defined as
 ```math
-k\\big((x, p_x), (x', p_{x'})\\big) = \\begin{cases}
-    \\widetilde{k}(x, x') & \\text{if } p_x = p_{x'}, \\\\
+\\widetilde{k}\\big((x, p_x), (x', p_{x'})\\big) = \\begin{cases}
+    k(x, x') & \\text{if } p_x = p_{x'}, \\\\
     0 & \\text{otherwise}.
 \\end{cases}
 ```
 Mathematically, it is equivalent to a matrix-valued kernel defined as
 ```math
-k(x, x') = \\mathrm{diag}\\big(k(x, x'), \\ldots, k(x, x')\\big) \\in \\mathbb{R}^{k \\times k},
+\\widetilde{K}(x, x') = \\mathrm{diag}\\big(k(x, x'), \\ldots, k(x, x')\\big) \\in \\mathbb{R}^{m \\times m},
 ```
-where ``k`` is the number of output dimensions.
+where ``m`` is the number of outputs.
 """
 struct IndependentMOKernel{Tkernel<:Kernel} <: MOKernel
     kernel::Tkernel

--- a/src/mokernels/independent.jl
+++ b/src/mokernels/independent.jl
@@ -1,7 +1,23 @@
 """
-    IndependentMOKernel(k::Kernel) <: Kernel
+    IndependentMOKernel(k::Kernel)
 
-A Multi-Output kernel which assumes each output is independent of the other.
+Kernel for multiple independent outputs with kernel `k`.
+
+# Definition
+
+For inputs ``x, x'`` and output dimensions ``p_x, p_{x'}'``, the kernel for independent
+outputs with kernel ``\\widetilde{k}`` is defined as
+```math
+k\\big((x, p_x), (x', p_{x'})\\big) = \\begin{cases}
+    \\widetilde{k}(x, x') & \\text{if } p_x = p_{x'}, \\\\
+    0 & \\text{otherwise}.
+\\end{cases}
+```
+Mathematically, it is equivalent to a matrix-valued kernel defined as
+```math
+k(x, x') = \\mathrm{diag}\\big(k(x, x'), \\ldots, k(x, x')\\big) \\in \\mathbb{R}^{k \\times k},
+```
+where ``k`` is the number of output dimensions.
 """
 struct IndependentMOKernel{Tkernel<:Kernel} <: MOKernel
     kernel::Tkernel

--- a/src/mokernels/mokernel.jl
+++ b/src/mokernels/mokernel.jl
@@ -1,6 +1,6 @@
 """
     MOKernel
 
-An abstract type for kernels with multiple outpus.
+Abstract type for kernels with multiple outpus.
 """
 abstract type MOKernel <: Kernel end

--- a/src/mokernels/mokernel.jl
+++ b/src/mokernels/mokernel.jl
@@ -1,6 +1,6 @@
 """
     MOKernel
 
-An abstract type for multi-output kernels.
+An abstract type for kernels with multiple outpus.
 """
 abstract type MOKernel <: Kernel end

--- a/src/mokernels/slfm.jl
+++ b/src/mokernels/slfm.jl
@@ -1,20 +1,18 @@
 @doc raw"""
     LatentFactorMOKernel(g, e::MOKernel, A::AbstractMatrix)
 
-The kernel associated with the Semiparametric Latent Factor Model, introduced by 
-Seeger, Teh and Jordan (2005).
+Kernel associated with the semiparametric latent factor model.
 
-``k((x, p_x), (y, p_y)) = \Sum^{Q}_{q=1} A_{p_xq}g_q(x, y)A_{p_yq} + e((x, p_x), (y, p_y))``
+# Definition
 
-# Arguments
-- `g`: a collection of kernels, one for each latent process
-- `e`: a [`MOKernel`](@ref) - multi-output kernel
-- `A::AbstractMatrix`: a matrix of weights for the kernels of size `(out_dim, length(g))`
+The kernel is defined as[^STJ]
+```math
+k\big((x, p_x), (y, p_y)\big) = \sum^{Q}_{q=1} A_{p_xq}g_q(x, y)A_{p_yq} + e\big((x, p_x), (y, p_y)\big),
+```
+where ``g_1, \ldots, g_Q`` are ``Q`` kernels, one for each latent process, ``e`` is a
+kernel for ``k`` outputs, and ``A`` is a matrix of weights for the kernels of size ``k \times Q``.
 
-
-# Reference:
-- [Seeger, Teh, and Jordan (2005)](https://infoscience.epfl.ch/record/161465/files/slfm-long.pdf)
-
+[^STJ]: M. Seeger, Y. Teh, & M. I. Jordan (2005). [Semiparametric Latent Factor Models](https://infoscience.epfl.ch/record/161465/files/slfm-long.pdf).
 """
 struct LatentFactorMOKernel{Tg,Te<:MOKernel,TA<:AbstractMatrix} <: MOKernel
     g::Tg

--- a/src/mokernels/slfm.jl
+++ b/src/mokernels/slfm.jl
@@ -5,12 +5,14 @@ Kernel associated with the semiparametric latent factor model.
 
 # Definition
 
-The kernel is defined as[^STJ]
+For inputs ``x, x'`` and output dimensions ``p_x, p_{x'}'``, the kernel is defined as[^STJ]
 ```math
-k\big((x, p_x), (y, p_y)\big) = \sum^{Q}_{q=1} A_{p_xq}g_q(x, y)A_{p_yq} + e\big((x, p_x), (y, p_y)\big),
+k\big((x, p_x), (x, p_{x'})\big) = \sum^{Q}_{q=1} A_{p_xq}g_q(x, x')A_{p_{x'}q}
+                                   + e\big((x, p_x), (x', p_{x'})\big),
 ```
 where ``g_1, \ldots, g_Q`` are ``Q`` kernels, one for each latent process, ``e`` is a
-kernel for ``k`` outputs, and ``A`` is a matrix of weights for the kernels of size ``k \times Q``.
+multi-output kernel for ``m`` outputs, and ``A`` is a matrix of weights for the kernels of
+size ``m \times Q``.
 
 [^STJ]: M. Seeger, Y. Teh, & M. I. Jordan (2005). [Semiparametric Latent Factor Models](https://infoscience.epfl.ch/record/161465/files/slfm-long.pdf).
 """

--- a/src/transform/ardtransform.jl
+++ b/src/transform/ardtransform.jl
@@ -19,7 +19,7 @@ end
 """
     ARDTransform(s::Real, dims::Integer)
 
-Create an [`ARDTransform`] with vector `fill(s, dims)`.
+Create an [`ARDTransform`](@ref) with vector `fill(s, dims)`.
 """
 ARDTransform(s::Real, dims::Integer) = ARDTransform(fill(s, dims))
 

--- a/src/transform/ardtransform.jl
+++ b/src/transform/ardtransform.jl
@@ -1,17 +1,26 @@
 """
     ARDTransform(v::AbstractVector)
-    ARDTransform(s::Real, dims::Int)
 
-Multiply every vector of observation by `v` element-wise
-```
-    v = rand(3)
-    tr = ARDTransform(v)
+Transformation that multiplies the input elementwise by `v`.
+
+# Examples
+
+```jldoctest
+julia> v = rand(10); t = ARDTransform(v); X = rand(10, 100);
+
+julia> map(t, ColVecs(X)) == ColVecs(v .* X)
+true
 ```
 """
 struct ARDTransform{Tv<:AbstractVector{<:Real}} <: Transform
     v::Tv
 end
 
+"""
+    ARDTransform(s::Real, dims::Integer)
+
+Create an [`ARDTransform`] with vector `fill(s, dims)`.
+"""
 ARDTransform(s::Real, dims::Integer) = ARDTransform(fill(s, dims))
 
 @functor ARDTransform

--- a/src/transform/chaintransform.jl
+++ b/src/transform/chaintransform.jl
@@ -1,12 +1,22 @@
 """
     ChainTransform(ts::AbstractVector{<:Transform})
 
-Chain a series of transform, here `t1` will be called first
-```
-    t1 = ScaleTransform()
-    t2 = LinearTransform(rand(3,4))
-    ct = ChainTransform([t1,t2]) #t1 will be called first
-    ct == t2 ∘ t1
+Transformation that applies a chain of transformations `ts` to the input.
+
+The transformation `first(ts)` is applied first.
+
+# Examples
+
+```jldoctest
+julia> l = rand(); A = rand(3, 4); t1 = ScaleTransform(l); t2 = LinearTransform(A);
+
+julia> X = rand(4, 10);
+
+julia> map(ChainTransform([t1, t2]), ColVecs(X)) == ColVecs(A * (l .* X))
+true
+
+julia> map(t2 ∘ t1, ColVecs(X)) == ColVecs(A * (l .* X))
+true
 ```
 """
 struct ChainTransform{V<:AbstractVector{<:Transform}} <: Transform

--- a/src/transform/functiontransform.jl
+++ b/src/transform/functiontransform.jl
@@ -1,12 +1,18 @@
 """
     FunctionTransform(f)
 
-Take a function or object `f` as an argument which is going to act on each vector individually.
-Make sure that `f` is supposed to act on a vector.
-For example replace `f(x)=sin(x)` by `f(x)=sin.(x)`
-```
-    f(x) = abs.(x)
-    tr = FunctionTransform(f)
+Transformation that applies function `f` to the input.
+
+Make sure that `f` can act on an input. For instance, if the inputs are vectors, use
+`f(x) = sin.(x)` instead of `f = sin`.
+
+# Examples
+
+```jldoctest
+julia> f(x) = sum(x); t = FunctionTransform(f); X = randn(100, 10);
+
+julia> map(t, ColVecs(X)) == ColVecs(sum(X; dims=1))
+true
 ```
 """
 struct FunctionTransform{F} <: Transform

--- a/src/transform/lineartransform.jl
+++ b/src/transform/lineartransform.jl
@@ -1,15 +1,17 @@
 """
     LinearTransform(A::AbstractMatrix)
 
-Apply the linear transformation realised by the matrix `A`.
+Linear transformation of the input realised by the matrix `A`.
 
 The second dimension of `A` must match the number of features of the target.
 
 # Examples
 
-```julia-repl
-julia> A = rand(10, 5)
-julia> tr = LinearTransform(A)
+```jldoctest
+julia> A = rand(10, 5); t = LinearTransform(A); X = rand(5, 100);
+
+julia> map(t, ColVecs(X)) == ColVecs(A * X)
+true
 ```
 """
 struct LinearTransform{T<:AbstractMatrix{<:Real}} <: Transform

--- a/src/transform/periodic_transform.jl
+++ b/src/transform/periodic_transform.jl
@@ -1,8 +1,19 @@
 """
     PeriodicTransform(f)
 
-Makes a kernel periodic by mapping a scalar input onto the unit circle. Samples from a GP
-with a kernel with this transformation applied will produce samples with frequency `f`.
+Transformation that maps the input elementwise onto the unit circle with frequency `f`.
+
+Samples from a GP with a kernel with this transformation applied to the inputs will produce
+samples with frequency `f`.
+
+# Examples
+
+```jldoctest
+julia> f = rand(); t = PeriodicTransform(f); x = rand();
+
+julia> t(x) == [sinpi(2 * f * x), cospi(2 * f * x)]
+true
+```
 """
 struct PeriodicTransform{Tf<:AbstractVector{<:Real}} <: Transform
     f::Tf

--- a/src/transform/scaletransform.jl
+++ b/src/transform/scaletransform.jl
@@ -1,10 +1,15 @@
 """
     ScaleTransform(l::Real)
 
-Multiply every element of the input by `l`
-```
-    l = 2.0
-    tr = ScaleTransform(l)
+Transformation that multiplies the input elementwise with `l`.
+
+# Examples
+
+```jldoctest
+julia> l = rand(); t = ScaleTransform(l); X = rand(100, 10);
+
+julia> map(t, ColVecs(X)) == ColVecs(l .* X)
+true
 ```
 """
 struct ScaleTransform{T<:Real} <: Transform

--- a/src/transform/selecttransform.jl
+++ b/src/transform/selecttransform.jl
@@ -1,12 +1,15 @@
 """
     SelectTransform(dims)
 
-Select the dimensions `dims` that the kernel is applied to.
-```
-    dims = [1,3,5,6,7]
-    tr = SelectTransform(dims)
-    X = rand(100,10)
-    transform(tr,X,obsdim=2) == X[dims,:]
+Transformation that selects the dimensions `dims` of the input.
+
+# Examples
+
+```jldoctest
+julia> dims = [1, 3, 5, 6, 7]; t = SelectTransform(dims); X = rand(100, 10);
+
+julia> map(t, ColVecs(X)) == ColVecs(X[dims, :])
+true
 ```
 """
 struct SelectTransform{T} <: Transform

--- a/src/transform/transform.jl
+++ b/src/transform/transform.jl
@@ -1,5 +1,7 @@
 """
-Abstract type defining a slice-wise transformation on an input matrix
+    Transform
+
+Abstract type defining a transformation of the input.
 """
 abstract type Transform end
 
@@ -9,7 +11,7 @@ _map(t::Transform, x::AbstractVector) = t.(x)
 """
     IdentityTransform()
 
-Return exactly the input
+Transformation that returns exactly the input.
 """
 struct IdentityTransform <: Transform end
 

--- a/test/basekernels/exponential.jl
+++ b/test/basekernels/exponential.jl
@@ -44,7 +44,7 @@
         @test repr(k) == "Gamma Exponential Kernel (γ = $(γ))"
         @test KernelFunctions.iskroncompatible(k) == true
 
-        test_ADs(γ -> GammaExponentialKernel(; gamma=first(γ)), [γ])
+        test_ADs(γ -> GammaExponentialKernel(; gamma=first(γ)), [1 + 0.5 * rand()])
         test_params(k, ([γ],))
         TestUtils.test_interface(GammaExponentialKernel(; γ=1.36))
 

--- a/test/basekernels/rationalquad.jl
+++ b/test/basekernels/rationalquad.jl
@@ -32,61 +32,60 @@
 
         @test repr(k) == "Gamma Rational Quadratic Kernel (α = 2.0, γ = 2.0)"
 
-        @testset "Default GammaRQ ≈ RQ for large α with rescaled inputs" begin
+        @testset "Default GammaRQ ≈ RQ" begin
             @test isapprox(
-                GammaRationalQuadraticKernel()(v1 ./ sqrt(2), v2 ./ sqrt(2)),
+                GammaRationalQuadraticKernel()(v1, v2),
                 RationalQuadraticKernel()(v1, v2),
             )
             a = 1.0 + rand()
             @test isapprox(
-                GammaRationalQuadraticKernel(; α=a)(v1 ./ sqrt(2), v2 ./ sqrt(2)),
+                GammaRationalQuadraticKernel(; α=a)(v1, v2),
                 RationalQuadraticKernel(; α=a)(v1, v2),
             )
         end
 
-        @testset "GammaRQ ≈ EQ for large α with rescaled inputs" begin
+        @testset "GammaRQ ≈ EQ for large α" begin
             v1 = randn(2)
             v2 = randn(2)
             @test isapprox(
-                GammaRationalQuadraticKernel(; α=1e9)(v1 ./ sqrt(2), v2 ./ sqrt(2)),
+                GammaRationalQuadraticKernel(; α=1e9)(v1, v2),
                 SqExponentialKernel()(v1, v2);
                 atol=1e-6,
                 rtol=1e-6,
             )
         end
 
-        @testset "GammaRQ(γ=1) ≈ Exponential with rescaled inputs for large α" begin
+        @testset "GammaRQ(γ=1) ≈ Exponential for large α with rescaled inputs" begin
             v1 = randn(4)
             v2 = randn(4)
             @test isapprox(
-                GammaRationalQuadraticKernel(; α=1e9, γ=1.0)(v1, v2),
+                GammaRationalQuadraticKernel(; α=1e9, γ=1.0)(2 .* v1, 2 .* v2),
                 ExponentialKernel()(v1, v2);
                 atol=1e-6,
                 rtol=1e-6,
             )
         end
 
-        @testset "GammaRQ ≈ GammaExponential for same γ and large α" begin
+        @testset "GammaRQ ≈ GammaExponential for same γ and large α with rescaled inputs" begin
             v1 = randn(3)
             v2 = randn(3)
             γ = rand() + 0.5
             @test isapprox(
-                GammaRationalQuadraticKernel(; α=1e9, γ=γ)(v1, v2),
+                GammaRationalQuadraticKernel(; α=1e9, γ=γ)(2^(1/γ) .* v1, 2^(1/γ) .* v2),
                 GammaExponentialKernel(; γ=γ)(v1, v2);
                 atol=1e-6,
                 rtol=1e-6,
             )
         end
 
-        @test metric(GammaRationalQuadraticKernel()) == SqEuclidean()
-        @test metric(GammaRationalQuadraticKernel(; γ=2.0)) == SqEuclidean()
-        @test metric(GammaRationalQuadraticKernel(; γ=2.0, α=3.0)) == SqEuclidean()
+        @test metric(GammaRationalQuadraticKernel()) == Euclidean()
+        @test metric(GammaRationalQuadraticKernel(; γ=2.0)) == Euclidean()
+        @test metric(GammaRationalQuadraticKernel(; γ=2.0, α=3.0)) == Euclidean()
 
         # Standardised tests.
         TestUtils.test_interface(k, Float64)
-        # test_ADs(x->GammaRationalQuadraticKernel(α=x[1], γ=x[2]), [a, 2.0])
-        @test_broken "All (problem with power operation)"
         a = 1.0 + rand()
+        test_ADs(x -> GammaRationalQuadraticKernel(α=x[1], γ=x[2]), [a, 1 + 0.5 * rand()])
         test_params(GammaRationalQuadraticKernel(; α=a, γ=x), ([a], [x]))
     end
 end

--- a/test/basekernels/rationalquad.jl
+++ b/test/basekernels/rationalquad.jl
@@ -34,8 +34,7 @@
 
         @testset "Default GammaRQ ≈ RQ" begin
             @test isapprox(
-                GammaRationalQuadraticKernel()(v1, v2),
-                RationalQuadraticKernel()(v1, v2),
+                GammaRationalQuadraticKernel()(v1, v2), RationalQuadraticKernel()(v1, v2)
             )
             a = 1.0 + rand()
             @test isapprox(
@@ -71,7 +70,9 @@
             v2 = randn(3)
             γ = rand() + 0.5
             @test isapprox(
-                GammaRationalQuadraticKernel(; α=1e9, γ=γ)(2^(1/γ) .* v1, 2^(1/γ) .* v2),
+                GammaRationalQuadraticKernel(; α=1e9, γ=γ)(
+                    2^(1 / γ) .* v1, 2^(1 / γ) .* v2
+                ),
                 GammaExponentialKernel(; γ=γ)(v1, v2);
                 atol=1e-6,
                 rtol=1e-6,
@@ -85,7 +86,7 @@
         # Standardised tests.
         TestUtils.test_interface(k, Float64)
         a = 1.0 + rand()
-        test_ADs(x -> GammaRationalQuadraticKernel(α=x[1], γ=x[2]), [a, 1 + 0.5 * rand()])
+        test_ADs(x -> GammaRationalQuadraticKernel(; α=x[1], γ=x[2]), [a, 1 + 0.5 * rand()])
         test_params(GammaRationalQuadraticKernel(; α=a, γ=x), ([a], [x]))
     end
 end

--- a/test/basekernels/rationalquad.jl
+++ b/test/basekernels/rationalquad.jl
@@ -32,47 +32,46 @@
 
         @test repr(k) == "Gamma Rational Quadratic Kernel (α = 2.0, γ = 2.0)"
 
-        @testset "Default GammaRQ ≈ RQ" begin
+        @testset "Default GammaRQ ≈ RQ with rescaled inputs" begin
             @test isapprox(
-                GammaRationalQuadraticKernel()(v1, v2), RationalQuadraticKernel()(v1, v2)
+                GammaRationalQuadraticKernel()(v1 ./ sqrt(2), v2 ./ sqrt(2)),
+                RationalQuadraticKernel()(v1, v2),
             )
             a = 1.0 + rand()
             @test isapprox(
-                GammaRationalQuadraticKernel(; α=a)(v1, v2),
+                GammaRationalQuadraticKernel(; α=a)(v1 ./ sqrt(2), v2 ./ sqrt(2)),
                 RationalQuadraticKernel(; α=a)(v1, v2),
             )
         end
 
-        @testset "GammaRQ ≈ EQ for large α" begin
+        @testset "GammaRQ ≈ EQ for large α with rescaled inputs" begin
             v1 = randn(2)
             v2 = randn(2)
             @test isapprox(
-                GammaRationalQuadraticKernel(; α=1e9)(v1, v2),
+                GammaRationalQuadraticKernel(; α=1e9)(v1 ./ sqrt(2), v2 ./ sqrt(2)),
                 SqExponentialKernel()(v1, v2);
                 atol=1e-6,
                 rtol=1e-6,
             )
         end
 
-        @testset "GammaRQ(γ=1) ≈ Exponential for large α with rescaled inputs" begin
+        @testset "GammaRQ(γ=1) ≈ Exponential with rescaled inputs for large α" begin
             v1 = randn(4)
             v2 = randn(4)
             @test isapprox(
-                GammaRationalQuadraticKernel(; α=1e9, γ=1.0)(2 .* v1, 2 .* v2),
+                GammaRationalQuadraticKernel(; α=1e9, γ=1.0)(v1, v2),
                 ExponentialKernel()(v1, v2);
                 atol=1e-6,
                 rtol=1e-6,
             )
         end
 
-        @testset "GammaRQ ≈ GammaExponential for same γ and large α with rescaled inputs" begin
+        @testset "GammaRQ ≈ GammaExponential for same γ and large α" begin
             v1 = randn(3)
             v2 = randn(3)
             γ = rand() + 0.5
             @test isapprox(
-                GammaRationalQuadraticKernel(; α=1e9, γ=γ)(
-                    2^(1 / γ) .* v1, 2^(1 / γ) .* v2
-                ),
+                GammaRationalQuadraticKernel(; α=1e9, γ=γ)(v1, v2),
                 GammaExponentialKernel(; γ=γ)(v1, v2);
                 atol=1e-6,
                 rtol=1e-6,

--- a/test/basekernels/wiener.jl
+++ b/test/basekernels/wiener.jl
@@ -14,8 +14,8 @@
     k3 = WienerKernel(; i=3)
     @test k3 isa WienerKernel{3}
 
-    @test_throws AssertionError WienerKernel(; i=4)
-    @test_throws AssertionError WienerKernel(; i=-2)
+    @test_throws ArgumentError WienerKernel(; i=4)
+    @test_throws ArgumentError WienerKernel(; i=-2)
 
     v1 = rand(4)
     v2 = rand(4)


### PR DESCRIPTION
Addresses https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/issues/218 and https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/issues/216 and uses the docstrings in the documentation of kernel functions and transformation.

The docstrings are updated and synced with the documentation, a bunch of errors are fixed (e.g., incorrect Matérn kernel functions and rational quadratic kernels), formatting of most docstrings of kernels and transformations is fixed (basically everything apart from the Wiener kernel and spectral mixture kernel, I was too tired to fix the mess there), doctests are added to most transformations, and incorrect explanations and outdated code of the transformations are fixed.