### PR TITLE
Fix formula of Gabor kernel

### DIFF
--- a/src/basekernels/gabor.jl
+++ b/src/basekernels/gabor.jl
@@ -8,8 +8,8 @@ Gabor kernel with lengthscale `ell` and period `p`.
 For inputs ``x, x' \\in \\mathbb{R}^d``, the Gabor kernel with lengthscale ``l_i > 0``
 and period ``p_i > 0`` is defined as
 ```math
-k(x, x'; l, p) = \\exp\\bigg(- \\cos\\bigg(\\pi\\sum_{i=1}^d \\frac{x_i - x'_i}{p_i}\\bigg)
-                             \\sum_{i=1}^d \\frac{(x_i - x'_i)^2}{l_i^2}\\bigg).
+k(x, x'; l, p) = \\exp\\bigg(- \\sum_{i=1}^d \\frac{(x_i - x'_i)^2}{2l_i^2}\\bigg)
+                 \\cos\\bigg(\\pi \\bigg(\\sum_{i=1}^d \\frac{(x_i - x'_i)^2}{p_i^2} \\bigg)^{1/2}\\bigg).
 ```
 """
 struct GaborKernel{K<:Kernel} <: Kernel


### PR DESCRIPTION
There's an inconsistency in the mathematical definition and the implementation that I missed. The Gabor kernel is implemented as a product of a Gaussian and a cosine kernel, both possibly with a (possibly element-wise) lengthscale transformation of the inputs. The formula should reflect this now correctly.

That being said, the Gabor kernel implementation is definitely one of the stranger implementations. It still feels weird to wrap the product in its own struct, a function `gabor` would be sufficient it seems. I am also wondering if one should drop one of the lengthscale transformations and instead define the kernel with `ell = 1` (or `p = 1`). One would have to apply a separate input transformation to set this parameter, as for other kernels currently, and scale the other parameter accordingly.