### PR TITLE
Deprecate `TensorProduct` correctly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.8.19"
+version = "0.8.20"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -8,7 +8,4 @@
     PiecewisePolynomialKernel{V}(size(A, 1)), LinearTransform(cholesky(A).U)
 )
 
-@deprecate TensorProduct(kernels) KernelTensorProduct(kernels)
-@deprecate TensorProduct(kernel::Kernel, kernels::Kernel...) KernelTensorProduct(
-    kernel, kernels...
-)
+Base.@deprecate_binding TensorProduct KernelTensorProduct

--- a/test/kernels/kerneltensorproduct.jl
+++ b/test/kernels/kerneltensorproduct.jl
@@ -28,9 +28,10 @@
     end
 
     # Deprecations
-    @test (@test_deprecated TensorProduct(k1, k2)) == k1 ⊗ k2
-    @test (@test_deprecated TensorProduct((k1, k2))) == k1 ⊗ k2
-    @test (@test_deprecated TensorProduct([k1, k2])) == k1 ⊗ k2
+    @test TensorProduct === KernelTensorProduct
+    @test TensorProduct(k1, k2) == k1 ⊗ k2
+    @test TensorProduct((k1, k2)) == k1 ⊗ k2
+    @test TensorProduct([k1, k2]) == k1 ⊗ k2
 
     # Standardised tests.
     TestUtils.test_interface(kernel1, ColVecs{Float64})


### PR DESCRIPTION
This PR corrects the deprecation of `TensorProduct` and makes sure that dispatches on `TensorProduct` still work correctly. Unfortunately, I learnt about `Base.@deprecate_binding` too late (see also https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/pull/242).