### PR TITLE
Show git diff for formatting instead of git diff --name-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           julia --project=test/ -e 'using JuliaFormatter; format(".", verbose=true)'
       - name: Format check
         run: |
-          CHANGED="$(git diff --name-only)"
+          CHANGED="$(git diff)"
           if [ ! -z "$CHANGED" ]; then
             >&2 echo "Some files have not been formatted !!!"
             echo "$CHANGED"


### PR DESCRIPTION
Right now, the format check only returns the faulty files, this is quite impractical to figure out what's wrong. The git diff would show what needs to be changed.