### PR TITLE
Fix kernel matrix functions for ScaledKernel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.8.24"
+version = "0.8.25"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/kernels/scaledkernel.jl
+++ b/src/kernels/scaledkernel.jl
@@ -40,19 +40,19 @@ end
 function kernelmatrix!(
     K::AbstractMatrix, κ::ScaledKernel, x::AbstractVector, y::AbstractVector
 )
-    kernelmatrix!(K, κ, x, y)
+    kernelmatrix!(K, κ.kernel, x, y)
     K .*= κ.σ²
     return K
 end
 
 function kernelmatrix!(K::AbstractMatrix, κ::ScaledKernel, x::AbstractVector)
-    kernelmatrix!(K, κ, x)
+    kernelmatrix!(K, κ.kernel, x)
     K .*= κ.σ²
     return K
 end
 
 function kernelmatrix_diag!(K::AbstractVector, κ::ScaledKernel, x::AbstractVector)
-    kernelmatrix_diag!(K, κ, x)
+    kernelmatrix_diag!(K, κ.kernel, x)
     K .*= κ.σ²
     return K
 end

--- a/test/kernels/scaledkernel.jl
+++ b/test/kernels/scaledkernel.jl
@@ -10,7 +10,7 @@
     @test ks(x, y) == (s * k)(x, y)
 
     # Standardised tests.
-    TestUtils.test_interface(k, Float64)
+    TestUtils.test_interface(ks, Float64)
     test_ADs(x -> exp(x[1]) * SqExponentialKernel(), rand(1))
 
     test_params(s * k, (k, [s]))


### PR DESCRIPTION
I noticed that some of the functions for `ScaledKernel` where incorrectly implemented, leading to a stack overflow when calling them. 

I thought I should add some tests for these cases, but then I saw that you have some general interface test function, so I was wondering if it might be better to add the mutating kernel matrix functions also to this interface test.