### PR TITLE
Avoid failures when cleaning docs

### DIFF
--- a/.github/workflows/doc_preview_cleanup.yml
+++ b/.github/workflows/doc_preview_cleanup.yml
@@ -22,3 +22,5 @@ jobs:
               git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
               git push --force origin gh-pages-new:gh-pages
             fi
+        env:
+            PRNUM: ${{ github.event.number }}

--- a/.github/workflows/doc_preview_cleanup.yml
+++ b/.github/workflows/doc_preview_cleanup.yml
@@ -12,17 +12,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: gh-pages
-
-      - name: Delete preview and history
+      - name: Delete preview and history + push changes
         run: |
-            git config user.name "Documenter.jl"
-            git config user.email "documenter@juliadocs.github.io"
-            git rm -rf "previews/PR$PRNUM"
-            git commit -m "delete preview"
-            git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
-        env:
-            PRNUM: ${{ github.event.number }}
-
-      - name: Push changes
-        run: |
-            git push --force origin gh-pages-new:gh-pages
+            if [ -d "previews/PR$PRNUM" ]; then
+              git config user.name "Documenter.jl"
+              git config user.email "documenter@juliadocs.github.io"
+              git rm -rf "previews/PR$PRNUM"
+              git commit -m "delete preview"
+              git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+              git push --force origin gh-pages-new:gh-pages
+            fi


### PR DESCRIPTION
This PR should make the cleanup action a bit safer. Currently it fails if the preview does not exist, e.g., if a PR is opened from a fork (e.g., https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/pull/261).