### PR TITLE
[WIP] Run format check for PRs from forks as well

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Format suggestions
+name: Format check
 
 on:
   pull_request:
@@ -14,7 +14,17 @@ jobs:
       - run: |
           julia  -e 'using Pkg; Pkg.add("JuliaFormatter")'
           julia  -e 'using JuliaFormatter; format("."; verbose=true)'
-      - uses: reviewdog/action-suggester@v1
+      - run: |
+          git diff > diff.txt
+          if [ -s diff.txt ]; then
+            echo 'code is not formatted correctly'
+            exit 1
+          else
+            echo 'code is formatted correctly!'
+            exit 0
+          fi
+      - uses: actions/upload-artifact@v2
+        if: failure()
         with:
-          tool_name: JuliaFormatter
-          fail_on_error: true
+          name: diff-${{ github.event.number }}
+          path: diff.txt

--- a/.github/workflows/format_suggestions.yml
+++ b/.github/workflows/format_suggestions.yml
@@ -1,0 +1,62 @@
+name: Suggest formatting
+
+on:
+  workflow_run:
+    workflows: ["Format check"]
+    types: [completed]
+
+jobs:
+  suggest:
+    name: Suggest formatting
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v3
+        id: download
+        with:
+          script: |
+            // find the artifact of the workflow that triggered this one
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name.startsWith("diff-")
+            })[0];
+
+            // download the artifact
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/diff.zip', Buffer.from(download.data));
+
+            // return the number of the underlying PR encoded in the name of the artifact
+            // PRs from forks are not listed under github.event.workflow_run.pull_requests
+            var pr = matchArtifact.name.substring(5));
+            return pr
+          result-encoding: string
+      - name: Extract artifact
+        run: unzip diff.zip
+      - name: Install reviewdog
+        uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
+      - name: Run reviewdog
+        env:
+          CI_PULL_REQUEST: ${{ steps.download.outputs.result }}
+          CI_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          CI_REPO_OWNER: ${{ github.event.workflow_run.repository.owner.login }}
+          CI_REPO_NAME: ${{ github.event.workflow_run.repository.name }}
+          CI_REPOSITORY: ${{ github.event.workflow_run.repository }}
+          CI_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          reviewdog -name="Julia Formatter" -f=diff -f.diff.strip=1 -reporter="github-pr-review" < ./diff.txt

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -1,8 +1,7 @@
 module KernelFunctions
 
 if !isfile(joinpath(@__DIR__, "update_v0.8.0"))
-    printstyled(
-        stdout,
+    printstyled(stdout,
         """
         WARNING: SqExponentialKernel changed convention in version 0.8.0.
         This kernel now divides the squared distance by 2 to align with standard practice.


### PR DESCRIPTION
In principle, it should be possible to run format checks (and build the documentation) also when a PR is opened from a fork.

The security settings on Github do not allow actions triggered by forks to post suggestions or commit to the repo. However, one can upload artifacts (e.g., the diff of the formatter output or the generated documentation) and reuse them in a `workflow_run` that has write permissions and is always run with the version from the main repo (if I understand correctly). Unfortunately, it is a bit tricky to download the artifacts in the `workflow_run` action and one has to somehow save the number of the PR manually if needed (e.g., by saving it in a text file that is part of the artifacts or, as in this PR, as part of the name of the zipped artifacts).

I am not sure if it works, and probably one should test the setup in a separate dummy repo if ne wants to make sure that it actually works for PRs from forks.