### PR TITLE
Added \circ syntax for kernel input transformations

### DIFF
--- a/src/kernels/transformedkernel.jl
+++ b/src/kernels/transformedkernel.jl
@@ -51,6 +51,9 @@ function transform(k::TransformedKernel, t::Transform)
     return TransformedKernel(k.kernel, t ∘ k.transform)
 end
 
+Base.:∘(k::Kernel, t::Transform) = TransformedKernel(k, t)
+Base.:∘(k::TransformedKernel, t::Transform) = TransformedKernel(k.kernel, k.transform ∘ t)
+
 """
     transform(k::Kernel, ρ::Real)
 

--- a/test/kernels/transformedkernel.jl
+++ b/test/kernels/transformedkernel.jl
@@ -12,8 +12,10 @@
     ktard = TransformedKernel(k, ARDTransform(v))
     @test kt(v1, v2) == transform(k, ScaleTransform(s))(v1, v2)
     @test kt(v1, v2) == transform(k, s)(v1, v2)
+    @test kt(v1, v2) == (k ∘ ScaleTransform(s))(v1, v2)
     @test kt(v1, v2) ≈ k(s * v1, s * v2) atol = 1e-5
     @test ktard(v1, v2) ≈ transform(k, ARDTransform(v))(v1, v2) atol = 1e-5
+    @test ktard(v1, v2) == (k ∘ ARDTransform(v))(v1, v2)
     @test ktard(v1, v2) == transform(k, v)(v1, v2)
     @test ktard(v1, v2) == k(v .* v1, v .* v2)
     @test transform(kt, s2)(v1, v2) ≈ kt(s2 * v1, s2 * v2)
@@ -54,4 +56,9 @@
     test_params(transform(k, LinearTransform(P)), (k, P))
     test_params(transform(k, LinearTransform(P) ∘ ScaleTransform(s)), (k, [s], P))
     test_params(transform(k, FunctionTransform(c)), (k, c))
+
+    @test (k ∘ (LinearTransform(P') ∘ ScaleTransform(s)))(v1, v2) == ((k ∘ LinearTransform(P')) ∘ ScaleTransform(s))(v1, v2)
+    test_params(k ∘ LinearTransform(P), (P, k))
+    test_params(k ∘ LinearTransform(P) ∘ ScaleTransform(s), ([s], P, k))
+    test_params(k ∘ FunctionTransform(c), (c, k))
 end


### PR DESCRIPTION
I implemented my suggestions re: #217 by extending the \circ syntax to kernel/transformation compositions. For reasons explained in my comment there this behaves differently from `transform` for TransformedKernels in that the order of composition is different so as to preserve associativity.