### PR TITLE
Cancel previous running workflows on push

### DIFF
--- a/.github/workflows/Cancel.yml
+++ b/.github/workflows/Cancel.yml
@@ -1,0 +1,18 @@
+name: Cancel
+
+on:
+  workflow_run:
+    workflows:
+      - "CI"
+      - "Documentation"
+      - "Format suggestions"
+    types:
+      - requested
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: styfle/cancel-workflow-action@0.9.0
+      with:
+        workflow_id: ${{ github.event.workflow.id }}


### PR DESCRIPTION
Just learnt about https://github.com/styfle/cancel-workflow-action from https://github.com/JuliaDiff/ChainRules.jl/issues/426. Seems this could solve https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/issues/281.

I followed the instructions in https://github.com/styfle/cancel-workflow-action#advanced-pull-requests-from-forks which should also work for PRs from forks.