### PR TITLE
Improve cancel action

### DIFF
--- a/.github/workflows/Cancel.yml
+++ b/.github/workflows/Cancel.yml
@@ -15,4 +15,7 @@ jobs:
     steps:
     - uses: styfle/cancel-workflow-action@0.9.0
       with:
+        # cancel itself and all later-scheduled workflows, leaving only the latest
+        # helps if the pipeline is saturated
+        all_but_latest: true
         workflow_id: ${{ github.event.workflow.id }}


### PR DESCRIPTION
This PR adds a setting that allows the cancel action to cancel all actions apart from the latest, even later-scheduled actions. This should help if the pipeline is saturated.