### PR TITLE
Oops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Manifest.toml
 coverage/
 src/update_v0.8.0
+.DS_store

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.3"
+version = "0.10.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -42,7 +42,7 @@ export IndependentMOKernel, LatentFactorMOKernel, IntrinsicCoregionMOKernel
 export tensor, ⊗, compose
 
 using Compat
-using ChainRulesCore: ChainRulesCore, Tangent, ZeroTangent, One, DoesNotExist, NoTangent
+using ChainRulesCore: ChainRulesCore, Tangent, ZeroTangent, NoTangent
 using ChainRulesCore: @thunk, InplaceableThunk
 using CompositionsBase
 using Distances


### PR DESCRIPTION
I forgot to check CI to see if my last PR was running ChainRulesCore@0.10 -- it must have been running 0.9 because it missed this, and now master doesn't precompile 😂 

edit: I've also added `.DS_store` to the `.gitignore` because I realised it wasn't there.