### PR TITLE
Adding naive LMM model

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.11.5"
+version = "0.10.6"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.5"
+version = "0.11.5"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/docs/src/kernels.md
+++ b/docs/src/kernels.md
@@ -134,4 +134,6 @@ MOKernel
 IndependentMOKernel
 LatentFactorMOKernel
 IntrinsicCoregionMOKernel
+LinearMixingModelKernel
+LMMKernel
 ```

--- a/docs/src/kernels.md
+++ b/docs/src/kernels.md
@@ -135,5 +135,4 @@ IndependentMOKernel
 LatentFactorMOKernel
 IntrinsicCoregionMOKernel
 LinearMixingModelKernel
-LMMKernel
 ```

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -106,6 +106,7 @@ include(joinpath("mokernels", "moinput.jl"))
 include(joinpath("mokernels", "independent.jl"))
 include(joinpath("mokernels", "slfm.jl"))
 include(joinpath("mokernels", "intrinsiccoregion.jl"))
+include(joinpath("mokernels", "lmm.jl"))
 
 include("chainrules.jl")
 include("zygoterules.jl")

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -36,7 +36,10 @@ export spectral_mixture_kernel, spectral_mixture_product_kernel
 export ColVecs, RowVecs
 
 export MOInput
-export IndependentMOKernel, LatentFactorMOKernel, IntrinsicCoregionMOKernel
+export IndependentMOKernel,
+    LatentFactorMOKernel,
+    IntrinsicCoregionMOKernel,
+    NaiveLMMMOKernel
 
 # Reexports
 export tensor, ⊗, compose

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -39,7 +39,7 @@ export MOInput
 export IndependentMOKernel,
     LatentFactorMOKernel,
     IntrinsicCoregionMOKernel,
-    NaiveLMMMOKernel
+    NaiveLinearMixingModelKernel
 
 # Reexports
 export tensor, ⊗, compose

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -39,7 +39,7 @@ export MOInput
 export IndependentMOKernel,
     LatentFactorMOKernel,
     IntrinsicCoregionMOKernel,
-    NaiveLinearMixingModelKernel
+    LinearMixingModelKernel, LMMKernel
 
 # Reexports
 export tensor, ⊗, compose

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -39,7 +39,7 @@ export MOInput
 export IndependentMOKernel,
     LatentFactorMOKernel,
     IntrinsicCoregionMOKernel,
-    LinearMixingModelKernel, LMMKernel
+    LinearMixingModelKernel
 
 # Reexports
 export tensor, ⊗, compose

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -37,9 +37,7 @@ export ColVecs, RowVecs
 
 export MOInput
 export IndependentMOKernel,
-    LatentFactorMOKernel,
-    IntrinsicCoregionMOKernel,
-    LinearMixingModelKernel
+    LatentFactorMOKernel, IntrinsicCoregionMOKernel, LinearMixingModelKernel
 
 # Reexports
 export tensor, ⊗, compose

--- a/src/mokernels/lmm.jl
+++ b/src/mokernels/lmm.jl
@@ -1,0 +1,86 @@
+@doc raw"""
+    NaiveLMMMOKernel(g, e::MOKernel, A::AbstractMatrix)
+
+Kernel associated with the linear mixing model.
+
+# Definition
+
+For inputs ``x, x'`` and output dimensions ``p_x, p_{x'}'``, the kernel is defined as[^BPTHST]
+```math
+k\big((x, p_x), (x, p_{x'})\big) = H_{p_{x}}k_{simple}(x, x')H_{p_{x'}}
+```
+where ``k_1, \ldots, k_m`` are ``m`` kernels, one for each latent process, ``H`` is a
+mixing matrix of ``m`` basis vectors spanning the output space, and ``σ²`` is noise.
+
+[^BPTHST]: Wessel P. Bruinsma, Eric Perim, Will Tebbutt, J. Scott Hosking, Arno Solin, Richard E. Turner (2020). [Scalable Exact Inference in Multi-Output Gaussian Processes](https://arxiv.org/pdf/1911.06287.pdf).
+"""
+struct NaiveLMMMOKernel{Tk<:Union{Kernel, Vector{<:Kernel}}, Th<:AbstractMatrix, F<:Float64} <: MOKernel
+    K::Tk
+    H::Th
+    σ²::F
+    # if just a simple kernel is provided, we construct the MO kernel
+    function NaiveLMMMOKernel(k::SimpleKernel, H::AbstractMatrix, σ²)
+        σ² >= 0 || error("`σ²` must be positive")
+        m = size(H,2)
+        K = [k for i in 1:m]
+        return new{typeof(K),typeof(H),typeof(σ²)}(K,H,σ²)
+    end
+    function NaiveLMMMOKernel(K::Vector{<:Kernel}, H::AbstractMatrix, σ²)
+        σ² >= 0 || error("`σ²` must be positive")
+        return new{typeof(K),typeof(H),typeof(σ²)}(K,H,σ²)
+    end
+end
+
+function (κ::NaiveLMMMOKernel)((x, px)::Tuple{Any,Int}, (y, py)::Tuple{Any,Int})
+    (px > size(κ.H, 1) || py > size(κ.H, 1) || px < 1 || py < 1) &&
+    error("`px` and `py` must be within the range of the number of outputs")
+    m = size(κ.H,2)
+    K = Matrix(undef, m, m)
+    K .= 0
+    for i in 1:m
+        K[i, i] = κ.K[i](x, y)
+    end
+    return H[px,:]' * K * H[py,:]
+end
+
+# not optimized at all
+function kernelmatrix(k::NaiveLMMMOKernel, x::MOInput, y::MOInput)
+    x.out_dim == y.out_dim || error("`x` and `y` should have the same output dimension")
+    x.out_dim == size(k.H, 1) ||
+        error("Mixing matrix not compatible with the given multi-output inputs")
+    m = size(k.H,2)
+    n_x = size(x.x,1)
+    n_y = size(y.x,1)
+    Σ = Matrix(undef, n_x, n_y)
+    for i in 1:n_x
+        for j in i:n_y
+            K_xy = Matrix(undef, m, m)
+            K_xy .= 0
+            if x.x isa Union{ColVecs,RowVecs}
+                x′ = x.x.X[i]
+            else
+                x′ = x.x[i]
+            end
+            if y.x isa Union{ColVecs,RowVecs}
+                y′ = y.x.X[j]
+            else
+                y′ = y.x[j]
+            end
+                for h in 1:m
+                    K_xy[h, h] = k.K[h](x′, y′)
+                end
+            Σ[i,j] = k.H * K_xy * k.H'
+            Σ[j,i] = Σ[i,j]
+        end
+    end
+    return Σ + k.σ²*I
+end
+
+function Base.show(io::IO, k::NaiveLMMMOKernel)
+    return print(io, "Linear Mixing Model Multi-Output Kernel (naive implementation)")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", k::NaiveLMMMOKernel)
+    print(io, "Linear Mixing Model Multi-Output Kernel (naive implementation)\n\tkernels (K): ")
+    return join(io, k.K, "\n\t\t")
+end

--- a/src/mokernels/lmm.jl
+++ b/src/mokernels/lmm.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    NaiveLMMMOKernel(g, e::MOKernel, A::AbstractMatrix)
+    NaiveLinearMixingModelKernel(g, e::MOKernel, A::AbstractMatrix)
 
 Kernel associated with the linear mixing model.
 
@@ -17,24 +17,24 @@ mixing matrix of ``m`` basis vectors spanning the output space.
 
 [^BPTHST]: Wessel P. Bruinsma, Eric Perim, Will Tebbutt, J. Scott Hosking, Arno Solin, Richard E. Turner (2020). [Scalable Exact Inference in Multi-Output Gaussian Processes](https://arxiv.org/pdf/1911.06287.pdf).
 """
-struct NaiveLMMMOKernel{Tk<:AbstractVector{<:Kernel}, Th<:AbstractMatrix} <: MOKernel
+struct NaiveLinearMixingModelKernel{Tk<:AbstractVector{<:Kernel}, Th<:AbstractMatrix} <: MOKernel
     K::Tk
     H::Th
 end
 
-NaiveLMMMOKernel(k::Kernel, H::AbstractMatrix) = NaiveLMMMOKernel(Fill(k, size(H, 1)), H)
+NaiveLinearMixingModelKernel(k::Kernel, H::AbstractMatrix) = NaiveLinearMixingModelKernel(Fill(k, size(H, 1)), H)
 
-function (κ::NaiveLMMMOKernel)((x, px)::Tuple{Any,Int}, (y, py)::Tuple{Any,Int})
+function (κ::NaiveLinearMixingModelKernel)((x, px)::Tuple{Any,Int}, (y, py)::Tuple{Any,Int})
     (px > size(κ.H, 2) || py > size(κ.H, 2) || px < 1 || py < 1) &&
     error("`px` and `py` must be within the range of the number of outputs")
     return sum(κ.H[i, px] * κ.K[i](x, y) * κ.H[i, py] for i in 1:length(κ.K))
 end
 
-function Base.show(io::IO, k::NaiveLMMMOKernel)
+function Base.show(io::IO, k::NaiveLinearMixingModelKernel)
     return print(io, "Linear Mixing Model Multi-Output Kernel (naive implementation)")
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", k::NaiveLMMMOKernel)
+function Base.show(io::IO, mime::MIME"text/plain", k::NaiveLinearMixingModelKernel)
     print(io, "Linear Mixing Model Multi-Output Kernel (naive implementation). Kernels:")
     for k in k.K
         print(io, "\n\t")

--- a/src/mokernels/lmm.jl
+++ b/src/mokernels/lmm.jl
@@ -41,12 +41,3 @@ function Base.show(io::IO, mime::MIME"text/plain", k::LinearMixingModelKernel)
         show(io, mime, k)
     end
 end
-
-## Aliases ##
-
-"""
-    LMMKernel()
-
-Alias of [`LinearMixingModelKernel`](@ref).
-"""
-const LMMKernel = LinearMixingModelKernel

--- a/src/mokernels/lmm.jl
+++ b/src/mokernels/lmm.jl
@@ -34,7 +34,10 @@ function Base.show(io::IO, k::NaiveLMMMOKernel)
     return print(io, "Linear Mixing Model Multi-Output Kernel (naive implementation)")
 end
 
-function Base.show(io::IO, ::MIME"text/plain", k::NaiveLMMMOKernel)
-    print(io, "Linear Mixing Model Multi-Output Kernel (naive implementation)\n\tkernels (K): ")
-    return join(io, k.K, "\n\t\t")
+function Base.show(io::IO, mime::MIME"text/plain", k::NaiveLMMMOKernel)
+    print(io, "Linear Mixing Model Multi-Output Kernel (naive implementation). Kernels:")
+    for k in k.K
+        print(io, "\n\t")
+        show(io, mime, k)
+    end
 end

--- a/src/mokernels/lmm.jl
+++ b/src/mokernels/lmm.jl
@@ -27,7 +27,7 @@ NaiveLMMMOKernel(k::Kernel, H::AbstractMatrix) = NaiveLMMMOKernel(Fill(k, size(H
 function (κ::NaiveLMMMOKernel)((x, px)::Tuple{Any,Int}, (y, py)::Tuple{Any,Int})
     (px > size(κ.H, 2) || py > size(κ.H, 2) || px < 1 || py < 1) &&
     error("`px` and `py` must be within the range of the number of outputs")
-    return sum(H[i, px] * κ.K[i](x, y) * H[i, py] for i in 1:length(κ.K))
+    return sum(κ.H[i, px] * κ.K[i](x, y) * κ.H[i, py] for i in 1:length(κ.K))
 end
 
 function Base.show(io::IO, k::NaiveLMMMOKernel)

--- a/src/mokernels/lmm.jl
+++ b/src/mokernels/lmm.jl
@@ -10,6 +10,7 @@ For inputs ``x, x'`` and output dimensions ``p_x, p_{x'}'``, the kernel is defin
 k\big((x, p_x), (x, p_{x'})\big) = H_{p_{x}}K(x, x')H_{p_{x'}}
 ```
 where ``K(x, x') = Diag(k_1(x, x'), ..., k_m(x, x'))`` with zero off-diagonal entries.
+``H_{p_{x}}`` is the ``p_x``-th column of ``H`` and
 ``k_1, \ldots, k_m`` are ``m`` kernels, one for each latent process, ``H`` is a
 mixing matrix of ``m`` basis vectors spanning the output space.
 
@@ -30,44 +31,9 @@ struct NaiveLMMMOKernel{Tk<:AbstractVector{<:Kernel}, Th<:AbstractMatrix} <: MOK
 end
 
 function (κ::NaiveLMMMOKernel)((x, px)::Tuple{Any,Int}, (y, py)::Tuple{Any,Int})
-    (px > size(κ.H, 1) || py > size(κ.H, 1) || px < 1 || py < 1) &&
+    (px > size(κ.H, 2) || py > size(κ.H, 2) || px < 1 || py < 1) &&
     error("`px` and `py` must be within the range of the number of outputs")
-    m = size(κ.H,2)
-    K = Diagonal(map(k -> k(x, y), κ.K))
-    return dot(H[px,:], K, H[py,:])
-end
-
-# not optimized at all, to be improved
-function kernelmatrix(k::NaiveLMMMOKernel, x::MOInput, y::MOInput)
-    x.out_dim == y.out_dim || error("`x` and `y` should have the same output dimension")
-    x.out_dim == size(k.H, 1) ||
-        error("Mixing matrix not compatible with the given multi-output inputs")
-    m = size(k.H, 2)
-    n_x = size(x.x, 1)
-    n_y = size(y.x, 1)
-    Σ = Matrix(undef, n_x, n_y)
-    for i in 1:n_x
-        for j in i:n_y
-            K_xy = Matrix(undef, m, m)
-            K_xy .= 0
-            if x.x isa Union{ColVecs,RowVecs}
-                x′ = x.x.X[i]
-            else
-                x′ = x.x[i]
-            end
-            if y.x isa Union{ColVecs,RowVecs}
-                y′ = y.x.X[j]
-            else
-                y′ = y.x[j]
-            end
-                for h in 1:m
-                    K_xy[h, h] = k.K[h](x′, y′)
-                end
-            Σ[i,j] = k.H * K_xy * k.H'
-            Σ[j,i] = Σ[i,j]
-        end
-    end
-    return Σ
+    return sum(H[i, px] * κ.K[i](x, y) * H[i, py] for i in 1:length(κ.K))
 end
 
 function Base.show(io::IO, k::NaiveLMMMOKernel)

--- a/src/mokernels/lmm.jl
+++ b/src/mokernels/lmm.jl
@@ -17,12 +17,14 @@ mixing matrix of ``m`` basis vectors spanning the output space.
 
 [^BPTHST]: Wessel P. Bruinsma, Eric Perim, Will Tebbutt, J. Scott Hosking, Arno Solin, Richard E. Turner (2020). [Scalable Exact Inference in Multi-Output Gaussian Processes](https://arxiv.org/pdf/1911.06287.pdf).
 """
-struct LinearMixingModelKernel{Tk<:AbstractVector{<:Kernel}, Th<:AbstractMatrix} <: MOKernel
+struct LinearMixingModelKernel{Tk<:AbstractVector{<:Kernel},Th<:AbstractMatrix} <: MOKernel
     K::Tk
     H::Th
 end
 
-LinearMixingModelKernel(k::Kernel, H::AbstractMatrix) = LinearMixingModelKernel(Fill(k, size(H, 1)), H)
+function LinearMixingModelKernel(k::Kernel, H::AbstractMatrix)
+    return LinearMixingModelKernel(Fill(k, size(H, 1)), H)
+end
 
 function (κ::LinearMixingModelKernel)((x, px)::Tuple{Any,Int}, (y, py)::Tuple{Any,Int})
     (px > size(κ.H, 2) || py > size(κ.H, 2) || px < 1 || py < 1) &&

--- a/src/mokernels/lmm.jl
+++ b/src/mokernels/lmm.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    NaiveLinearMixingModelKernel(g, e::MOKernel, A::AbstractMatrix)
+    LinearMixingModelKernel(g, e::MOKernel, A::AbstractMatrix)
 
 Kernel associated with the linear mixing model.
 
@@ -7,37 +7,46 @@ Kernel associated with the linear mixing model.
 
 For inputs ``x, x'`` and output dimensions ``p_x, p_{x'}'``, the kernel is defined as[^BPTHST]
 ```math
-k\big((x, p_x), (x, p_{x'})\big) = H_{p_{x}}K(x, x')H_{p_{x'}}
+k\big((x, p_x), (x, p_{x'})\big) = H_{:,p_{x}}K(x, x')H_{:,p_{x'}}
 ```
 where ``K(x, x') = Diag(k_1(x, x'), ..., k_m(x, x'))`` with zero off-diagonal entries.
-``H_{p_{x}}`` is the ``p_x``-th column (`p_x`-th output) of ``H \in \mathbb{R}^{m \times p}``
+``H_{:,p_{x}}`` is the ``p_x``-th column (`p_x`-th output) of ``H \in \mathbb{R}^{m \times p}``
 representing ``m`` basis vectors for the ``p`` dimensional output space of ``f``.
 ``k_1, \ldots, k_m`` are ``m`` kernels, one for each latent process, ``H`` is a
 mixing matrix of ``m`` basis vectors spanning the output space.
 
 [^BPTHST]: Wessel P. Bruinsma, Eric Perim, Will Tebbutt, J. Scott Hosking, Arno Solin, Richard E. Turner (2020). [Scalable Exact Inference in Multi-Output Gaussian Processes](https://arxiv.org/pdf/1911.06287.pdf).
 """
-struct NaiveLinearMixingModelKernel{Tk<:AbstractVector{<:Kernel}, Th<:AbstractMatrix} <: MOKernel
+struct LinearMixingModelKernel{Tk<:AbstractVector{<:Kernel}, Th<:AbstractMatrix} <: MOKernel
     K::Tk
     H::Th
 end
 
-NaiveLinearMixingModelKernel(k::Kernel, H::AbstractMatrix) = NaiveLinearMixingModelKernel(Fill(k, size(H, 1)), H)
+LinearMixingModelKernel(k::Kernel, H::AbstractMatrix) = LinearMixingModelKernel(Fill(k, size(H, 1)), H)
 
-function (κ::NaiveLinearMixingModelKernel)((x, px)::Tuple{Any,Int}, (y, py)::Tuple{Any,Int})
+function (κ::LinearMixingModelKernel)((x, px)::Tuple{Any,Int}, (y, py)::Tuple{Any,Int})
     (px > size(κ.H, 2) || py > size(κ.H, 2) || px < 1 || py < 1) &&
     error("`px` and `py` must be within the range of the number of outputs")
     return sum(κ.H[i, px] * κ.K[i](x, y) * κ.H[i, py] for i in 1:length(κ.K))
 end
 
-function Base.show(io::IO, k::NaiveLinearMixingModelKernel)
-    return print(io, "Linear Mixing Model Multi-Output Kernel (naive implementation)")
+function Base.show(io::IO, k::LinearMixingModelKernel)
+    return print(io, "Linear Mixing Model Multi-Output Kernel")
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", k::NaiveLinearMixingModelKernel)
-    print(io, "Linear Mixing Model Multi-Output Kernel (naive implementation). Kernels:")
+function Base.show(io::IO, mime::MIME"text/plain", k::LinearMixingModelKernel)
+    print(io, "Linear Mixing Model Multi-Output Kernel. Kernels:")
     for k in k.K
         print(io, "\n\t")
         show(io, mime, k)
     end
 end
+
+## Aliases ##
+
+"""
+    LMMKernel()
+
+Alias of [`LinearMixingModelKernel`](@ref).
+"""
+const LMMKernel = LinearMixingModelKernel

--- a/src/mokernels/lmm.jl
+++ b/src/mokernels/lmm.jl
@@ -10,7 +10,8 @@ For inputs ``x, x'`` and output dimensions ``p_x, p_{x'}'``, the kernel is defin
 k\big((x, p_x), (x, p_{x'})\big) = H_{p_{x}}K(x, x')H_{p_{x'}}
 ```
 where ``K(x, x') = Diag(k_1(x, x'), ..., k_m(x, x'))`` with zero off-diagonal entries.
-``H_{p_{x}}`` is the ``p_x``-th column of ``H`` and
+``H_{p_{x}}`` is the ``p_x``-th column (`p_x`-th output) of ``H \in \mathbb{R}^{m \times p}``
+representing ``m`` basis vectors for the ``p`` dimensional output space of ``f``.
 ``k_1, \ldots, k_m`` are ``m`` kernels, one for each latent process, ``H`` is a
 mixing matrix of ``m`` basis vectors spanning the output space.
 
@@ -19,16 +20,9 @@ mixing matrix of ``m`` basis vectors spanning the output space.
 struct NaiveLMMMOKernel{Tk<:AbstractVector{<:Kernel}, Th<:AbstractMatrix} <: MOKernel
     K::Tk
     H::Th
-    # if just a simple kernel is provided, we construct the MO kernel
-    function NaiveLMMMOKernel(k::SimpleKernel, H::AbstractMatrix)
-        m = size(H,2)
-        K = fill(k, m)
-        return new{typeof(K),typeof(H)}(K,H)
-    end
-    function NaiveLMMMOKernel(K::AbstractVector{<:Kernel}, H::AbstractMatrix)
-        return new{typeof(K),typeof(H)}(K,H)
-    end
 end
+
+NaiveLMMMOKernel(k::Kernel, H::AbstractMatrix) = NaiveLMMMOKernel(Fill(k, size(H, 1)), H)
 
 function (κ::NaiveLMMMOKernel)((x, px)::Tuple{Any,Int}, (y, py)::Tuple{Any,Int})
     (px > size(κ.H, 2) || py > size(κ.H, 2) || px < 1 || py < 1) &&

--- a/src/mokernels/lmm.jl
+++ b/src/mokernels/lmm.jl
@@ -26,7 +26,7 @@ LinearMixingModelKernel(k::Kernel, H::AbstractMatrix) = LinearMixingModelKernel(
 
 function (κ::LinearMixingModelKernel)((x, px)::Tuple{Any,Int}, (y, py)::Tuple{Any,Int})
     (px > size(κ.H, 2) || py > size(κ.H, 2) || px < 1 || py < 1) &&
-    error("`px` and `py` must be within the range of the number of outputs")
+        error("`px` and `py` must be within the range of the number of outputs")
     return sum(κ.H[i, px] * κ.K[i](x, y) * κ.H[i, py] for i in 1:length(κ.K))
 end
 

--- a/src/mokernels/lmm.jl
+++ b/src/mokernels/lmm.jl
@@ -11,24 +11,21 @@ k\big((x, p_x), (x, p_{x'})\big) = H_{p_{x}}K(x, x')H_{p_{x'}}
 ```
 where ``K(x, x') = Diag(k_1(x, x'), ..., k_m(x, x'))`` with zero off-diagonal entries.
 ``k_1, \ldots, k_m`` are ``m`` kernels, one for each latent process, ``H`` is a
-mixing matrix of ``m`` basis vectors spanning the output space, and ``σ²`` is noise.
+mixing matrix of ``m`` basis vectors spanning the output space.
 
 [^BPTHST]: Wessel P. Bruinsma, Eric Perim, Will Tebbutt, J. Scott Hosking, Arno Solin, Richard E. Turner (2020). [Scalable Exact Inference in Multi-Output Gaussian Processes](https://arxiv.org/pdf/1911.06287.pdf).
 """
-struct NaiveLMMMOKernel{Tk<:AbstractVector{<:Kernel}, Th<:AbstractMatrix, F<:Float64} <: MOKernel
+struct NaiveLMMMOKernel{Tk<:AbstractVector{<:Kernel}, Th<:AbstractMatrix} <: MOKernel
     K::Tk
     H::Th
-    σ²::F
     # if just a simple kernel is provided, we construct the MO kernel
-    function NaiveLMMMOKernel(k::SimpleKernel, H::AbstractMatrix, σ²)
-        σ² >= 0 || error("`σ²` must be positive")
+    function NaiveLMMMOKernel(k::SimpleKernel, H::AbstractMatrix)
         m = size(H,2)
         K = fill(k, m)
-        return new{typeof(K),typeof(H),typeof(σ²)}(K,H,σ²)
+        return new{typeof(K),typeof(H)}(K,H)
     end
-    function NaiveLMMMOKernel(K::AbstractVector{<:Kernel}, H::AbstractMatrix, σ²)
-        σ² >= 0 || error("`σ²` must be positive")
-        return new{typeof(K),typeof(H),typeof(σ²)}(K,H,σ²)
+    function NaiveLMMMOKernel(K::AbstractVector{<:Kernel}, H::AbstractMatrix)
+        return new{typeof(K),typeof(H)}(K,H)
     end
 end
 
@@ -36,22 +33,18 @@ function (κ::NaiveLMMMOKernel)((x, px)::Tuple{Any,Int}, (y, py)::Tuple{Any,Int}
     (px > size(κ.H, 1) || py > size(κ.H, 1) || px < 1 || py < 1) &&
     error("`px` and `py` must be within the range of the number of outputs")
     m = size(κ.H,2)
-    K = Matrix(undef, m, m)
-    K .= 0
-    for i in 1:m
-        K[i, i] = κ.K[i](x, y)
-    end
-    return H[px,:]' * K * H[py,:] + σ²
+    K = Diagonal(map(k -> k(x, y), κ.K))
+    return dot(H[px,:], K, H[py,:])
 end
 
-# not optimized at all
+# not optimized at all, to be improved
 function kernelmatrix(k::NaiveLMMMOKernel, x::MOInput, y::MOInput)
     x.out_dim == y.out_dim || error("`x` and `y` should have the same output dimension")
     x.out_dim == size(k.H, 1) ||
         error("Mixing matrix not compatible with the given multi-output inputs")
-    m = size(k.H,2)
-    n_x = size(x.x,1)
-    n_y = size(y.x,1)
+    m = size(k.H, 2)
+    n_x = size(x.x, 1)
+    n_y = size(y.x, 1)
     Σ = Matrix(undef, n_x, n_y)
     for i in 1:n_x
         for j in i:n_y
@@ -74,7 +67,7 @@ function kernelmatrix(k::NaiveLMMMOKernel, x::MOInput, y::MOInput)
             Σ[j,i] = Σ[i,j]
         end
     end
-    return Σ + k.σ²*I
+    return Σ
 end
 
 function Base.show(io::IO, k::NaiveLMMMOKernel)

--- a/test/mokernels/lmm.jl
+++ b/test/mokernels/lmm.jl
@@ -10,8 +10,7 @@
 
     k = NaiveLMMMOKernel(
         [Matern32Kernel(), SqExponentialKernel(), FBMKernel(), Matern32Kernel()],
-        H,
-        0.5
+        H
     )
     @test k isa NaiveLMMMOKernel
     @test k isa MOKernel

--- a/test/mokernels/lmm.jl
+++ b/test/mokernels/lmm.jl
@@ -8,35 +8,38 @@
     x2 = MOInput([rand(rng, in_dim) for _ in 1:N], out_dim)
     H = rand(4,6)
 
-    k = NaiveLinearMixingModelKernel(
+    k = LinearMixingModelKernel(
         [Matern32Kernel(), SqExponentialKernel(), FBMKernel(), Matern32Kernel()],
         H
     )
-    @test k isa NaiveLinearMixingModelKernel
+    @test k isa LinearMixingModelKernel
     @test k isa MOKernel
     @test k isa Kernel
     @test k(x1[1], x2[1]) isa Real
 
-    @test string(k) == "Linear Mixing Model Multi-Output Kernel (naive implementation)"
+    @test string(k) == "Linear Mixing Model Multi-Output Kernel"
     @test repr("text/plain", k) == (
-        "Linear Mixing Model Multi-Output Kernel (naive implementation). Kernels:\n" *
+        "Linear Mixing Model Multi-Output Kernel. Kernels:\n" *
         "\tMatern 3/2 Kernel (metric = Euclidean(0.0))\n" *
         "\tSquared Exponential Kernel (metric = Euclidean(0.0))\n" *
         "\tFractional Brownian Motion Kernel (h = 0.5)\n" *
         "\tMatern 3/2 Kernel (metric = Euclidean(0.0))"
     )
 
-    k = NaiveLinearMixingModelKernel(
+    k = LMMKernel(
         SEKernel(),
         H
     )
 
+    @test k isa LMMKernel
+    @test k isa MOKernel
+    @test k isa Kernel
     @test length(k.K) == 4
     for kernel in k.K @test isa(kernel, SEKernel) end
 
-    @test string(k) == "Linear Mixing Model Multi-Output Kernel (naive implementation)"
+    @test string(k) == "Linear Mixing Model Multi-Output Kernel"
     @test repr("text/plain", k) == (
-        "Linear Mixing Model Multi-Output Kernel (naive implementation). Kernels:\n" *
+        "Linear Mixing Model Multi-Output Kernel. Kernels:\n" *
         "\tSquared Exponential Kernel (metric = Euclidean(0.0))\n" *
         "\tSquared Exponential Kernel (metric = Euclidean(0.0))\n" *
         "\tSquared Exponential Kernel (metric = Euclidean(0.0))\n" *

--- a/test/mokernels/lmm.jl
+++ b/test/mokernels/lmm.jl
@@ -8,11 +8,11 @@
     x2 = MOInput([rand(rng, in_dim) for _ in 1:N], out_dim)
     H = rand(4,6)
 
-    k = NaiveLMMMOKernel(
+    k = NaiveLinearMixingModelKernel(
         [Matern32Kernel(), SqExponentialKernel(), FBMKernel(), Matern32Kernel()],
         H
     )
-    @test k isa NaiveLMMMOKernel
+    @test k isa NaiveLinearMixingModelKernel
     @test k isa MOKernel
     @test k isa Kernel
     @test k(x1[1], x2[1]) isa Real
@@ -26,7 +26,7 @@
         "\tMatern 3/2 Kernel (metric = Euclidean(0.0))"
     )
 
-    k = NaiveLMMMOKernel(
+    k = NaiveLinearMixingModelKernel(
         SEKernel(),
         H
     )

--- a/test/mokernels/lmm.jl
+++ b/test/mokernels/lmm.jl
@@ -6,11 +6,10 @@
     out_dim = 6
     x1 = MOInput([rand(rng, in_dim) for _ in 1:N], out_dim)
     x2 = MOInput([rand(rng, in_dim) for _ in 1:N], out_dim)
-    H = rand(4,6)
+    H = rand(4, 6)
 
     k = LinearMixingModelKernel(
-        [Matern32Kernel(), SqExponentialKernel(), FBMKernel(), Matern32Kernel()],
-        H
+        [Matern32Kernel(), SqExponentialKernel(), FBMKernel(), Matern32Kernel()], H
     )
     @test k isa LinearMixingModelKernel
     @test k isa MOKernel
@@ -26,16 +25,15 @@
         "\tMatern 3/2 Kernel (metric = Euclidean(0.0))"
     )
 
-    k = LMMKernel(
-        SEKernel(),
-        H
-    )
+    k = LMMKernel(SEKernel(), H)
 
     @test k isa LMMKernel
     @test k isa MOKernel
     @test k isa Kernel
     @test length(k.K) == 4
-    for kernel in k.K @test isa(kernel, SEKernel) end
+    for kernel in k.K
+        @test isa(kernel, SEKernel)
+    end
 
     @test string(k) == "Linear Mixing Model Multi-Output Kernel"
     @test repr("text/plain", k) == (

--- a/test/mokernels/lmm.jl
+++ b/test/mokernels/lmm.jl
@@ -6,7 +6,7 @@
     out_dim = 6
     x1 = MOInput([rand(rng, in_dim) for _ in 1:N], out_dim)
     x2 = MOInput([rand(rng, in_dim) for _ in 1:N], out_dim)
-    H = rand(6,4)
+    H = rand(4,6)
 
     k = NaiveLMMMOKernel(
         [Matern32Kernel(), SqExponentialKernel(), FBMKernel(), Matern32Kernel()],
@@ -16,9 +16,6 @@
     @test k isa MOKernel
     @test k isa Kernel
     @test k(x1[1], x2[1]) isa Real
-
-    # @test kernelmatrix(k, x1, x2) ≈ kernelmatrix(k, collect(x1), collect(x2))
-    # @test kernelmatrix(k, x1, x1) ≈ kernelmatrix(k, x1)
 
     @test string(k) == "Linear Mixing Model Multi-Output Kernel (naive implementation)"
     @test repr("text/plain", k) == (

--- a/test/mokernels/lmm.jl
+++ b/test/mokernels/lmm.jl
@@ -27,18 +27,17 @@
     )
 
     # # AD test
-    # function test_naiveLMM(H::AbstractMatrix, x1, x2)
-    #     k = NaiveLMMMOKernel(
-    #         [Matern32Kernel(), SqExponentialKernel(), FBMKernel()],
-    #         H,
-    #         0.5
-    #     )
-    #     return k((x1, 1), (x2, 1))
-    # end
+    function test_naiveLMM(H::AbstractMatrix, x1, x2)
+        k = NaiveLMMMOKernel(
+            [Matern32Kernel(), SqExponentialKernel(), FBMKernel()],
+            H
+        )
+        return k((x1, 1), (x2, 1))
+    end
 
-    # a = rand()
-    # @test all(
-    #     FiniteDifferences.j′vp(FDM, test_naiveLMM, a, k.H, x1[1][1], x2[1][1]) .≈
-    #     Zygote.pullback(test_naiveLMM, k.H, x1[1][1], x2[1][1])[2](a),
-    # )
+    a = rand()
+    @test all(
+        FiniteDifferences.j′vp(FDM, test_naiveLMM, a, k.H, x1[1][1], x2[1][1]) .≈
+        Zygote.pullback(test_naiveLMM, k.H, x1[1][1], x2[1][1])[2](a),
+    )
 end

--- a/test/mokernels/lmm.jl
+++ b/test/mokernels/lmm.jl
@@ -19,11 +19,11 @@
 
     @test string(k) == "Linear Mixing Model Multi-Output Kernel (naive implementation)"
     @test repr("text/plain", k) == (
-        "Linear Mixing Model Multi-Output Kernel (naive implementation)\n" *
-        "\tkernels (K): Matern 3/2 Kernel (metric = Euclidean(0.0))\n" *
-        "\t\tSquared Exponential Kernel (metric = Euclidean(0.0))\n" *
-        "\t\tFractional Brownian Motion Kernel (h = 0.5)\n" *
-        "\t\tMatern 3/2 Kernel (metric = Euclidean(0.0))"
+        "Linear Mixing Model Multi-Output Kernel (naive implementation). Kernels:\n" *
+        "\tMatern 3/2 Kernel (metric = Euclidean(0.0))\n" *
+        "\tSquared Exponential Kernel (metric = Euclidean(0.0))\n" *
+        "\tFractional Brownian Motion Kernel (h = 0.5)\n" *
+        "\tMatern 3/2 Kernel (metric = Euclidean(0.0))"
     )
 
     # # AD test

--- a/test/mokernels/lmm.jl
+++ b/test/mokernels/lmm.jl
@@ -27,34 +27,21 @@
     )
 
     k = NaiveLMMMOKernel(
-        Matern32Kernel(),
+        SEKernel(),
         H
     )
 
     @test length(k.K) == 4
-    for kernel in k.K @test isa(kernel, Matern32Kernel) end
+    for kernel in k.K @test isa(kernel, SEKernel) end
 
     @test string(k) == "Linear Mixing Model Multi-Output Kernel (naive implementation)"
     @test repr("text/plain", k) == (
         "Linear Mixing Model Multi-Output Kernel (naive implementation). Kernels:\n" *
-        "\tMatern 3/2 Kernel (metric = Euclidean(0.0))\n" *
-        "\tMatern 3/2 Kernel (metric = Euclidean(0.0))\n" *
-        "\tMatern 3/2 Kernel (metric = Euclidean(0.0))\n" *
-        "\tMatern 3/2 Kernel (metric = Euclidean(0.0))"
+        "\tSquared Exponential Kernel (metric = Euclidean(0.0))\n" *
+        "\tSquared Exponential Kernel (metric = Euclidean(0.0))\n" *
+        "\tSquared Exponential Kernel (metric = Euclidean(0.0))\n" *
+        "\tSquared Exponential Kernel (metric = Euclidean(0.0))"
     )
 
-    # # AD test
-    function test_naiveLMM(H::AbstractMatrix, x1, x2)
-        k = NaiveLMMMOKernel(
-            [Matern32Kernel(), SqExponentialKernel(), FBMKernel()],
-            H
-        )
-        return k((x1, 1), (x2, 1))
-    end
-
-    a = rand()
-    @test all(
-        FiniteDifferences.j′vp(FDM, test_naiveLMM, a, k.H, x1[1][1], x2[1][1]) .≈
-        Zygote.pullback(test_naiveLMM, k.H, x1[1][1], x2[1][1])[2](a),
-    )
+    test_ADs(k)
 end

--- a/test/mokernels/lmm.jl
+++ b/test/mokernels/lmm.jl
@@ -26,6 +26,23 @@
         "\tMatern 3/2 Kernel (metric = Euclidean(0.0))"
     )
 
+    k = NaiveLMMMOKernel(
+        Matern32Kernel(),
+        H
+    )
+
+    @test length(k.K) == 4
+    for kernel in k.K @test isa(kernel, Matern32Kernel) end
+
+    @test string(k) == "Linear Mixing Model Multi-Output Kernel (naive implementation)"
+    @test repr("text/plain", k) == (
+        "Linear Mixing Model Multi-Output Kernel (naive implementation). Kernels:\n" *
+        "\tMatern 3/2 Kernel (metric = Euclidean(0.0))\n" *
+        "\tMatern 3/2 Kernel (metric = Euclidean(0.0))\n" *
+        "\tMatern 3/2 Kernel (metric = Euclidean(0.0))\n" *
+        "\tMatern 3/2 Kernel (metric = Euclidean(0.0))"
+    )
+
     # # AD test
     function test_naiveLMM(H::AbstractMatrix, x1, x2)
         k = NaiveLMMMOKernel(

--- a/test/mokernels/lmm.jl
+++ b/test/mokernels/lmm.jl
@@ -25,9 +25,9 @@
         "\tMatern 3/2 Kernel (metric = Euclidean(0.0))"
     )
 
-    k = LMMKernel(SEKernel(), H)
+    k = LinearMixingModelKernel(SEKernel(), H)
 
-    @test k isa LMMKernel
+    @test k isa LinearMixingModelKernel
     @test k isa MOKernel
     @test k isa Kernel
     @test length(k.K) == 4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,6 +140,7 @@ include("test_utils.jl")
         include(joinpath("mokernels", "independent.jl"))
         include(joinpath("mokernels", "slfm.jl"))
         include(joinpath("mokernels", "intrinsiccoregion.jl"))
+        include(joinpath("mokernels", "lmm.jl"))
     end
     @info "Ran tests on Multi-Output Kernels"
 


### PR DESCRIPTION
# Adding a naive implementation of the Linear Mixing Model

## What is the LMM?

The LMM is a model of GP that assumes `f(x) = H * g(x)` where `H` is a basis of `f` and ``g(x)` are  time varying coefficients  modelled independently with unit-variance GPs.

Resources:
* https://arxiv.org/pdf/1911.06287.pdf
* https://invenia.github.io/blog/2021/02/19/OILMM-pt1/

## Why is this just adding the naive LMM?

I will be adding the more efficient sibling, but as an intro to contributing here felt that the simpler implementation was the place to start!