### PR TITLE
Don't test FBM on Zygote

### DIFF
--- a/test/basekernels/fbm.jl
+++ b/test/basekernels/fbm.jl
@@ -13,7 +13,13 @@
 
     test_interface(k)
     @test repr(k) == "Fractional Brownian Motion Kernel (h = $(h))"
-    test_ADs(FBMKernel; ADs=[:ReverseDiff, :Zygote])
-    @test_broken "Tests failing for kernelmatrix(k, x) for ForwardDiff"
+    test_ADs(FBMKernel; ADs=[:ReverseDiff])
+
+    # Tests failing for ForwardDiff
+    @test_broken !isinf(ForwardDiff.gradient(x -> x[1]^x[2], [0.0, 0.9])[1])
+
+    # Zygote also doesn't work.
+    @test_broken !isinf(Zygote.gradient((x, y) -> sum(f.(x, y)), zeros(1), fill(0.9, 1))[1][1])
+
     test_params(k, ([h],))
 end

--- a/test/basekernels/fbm.jl
+++ b/test/basekernels/fbm.jl
@@ -15,10 +15,10 @@
     @test repr(k) == "Fractional Brownian Motion Kernel (h = $(h))"
     test_ADs(FBMKernel; ADs=[:ReverseDiff])
 
-    # Tests failing for ForwardDiff
-    @test_broken !isinf(ForwardDiff.gradient(x -> x[1]^x[2], [0.0, 0.9])[1])
 
-    # Zygote also doesn't work.
+    # Tests failing for ForwardDiff and Zygote.
+    # Related to: https://github.com/FluxML/Zygote.jl/issues/1036
+    @test_broken !isinf(ForwardDiff.gradient(x -> x[1]^x[2], [0.0, 0.9])[1])
     @test_broken !isinf(Zygote.gradient((x, y) -> sum(f.(x, y)), zeros(1), fill(0.9, 1))[1][1])
 
     test_params(k, ([h],))

--- a/test/basekernels/fbm.jl
+++ b/test/basekernels/fbm.jl
@@ -15,7 +15,6 @@
     @test repr(k) == "Fractional Brownian Motion Kernel (h = $(h))"
     test_ADs(FBMKernel; ADs=[:ReverseDiff])
 
-
     # Tests failing for ForwardDiff and Zygote.
     # Related to: https://github.com/FluxML/Zygote.jl/issues/1036
     @test_broken !isinf(ForwardDiff.gradient(x -> x[1]^x[2], [0.0, 0.9])[1])

--- a/test/basekernels/fbm.jl
+++ b/test/basekernels/fbm.jl
@@ -15,12 +15,17 @@
     @test repr(k) == "Fractional Brownian Motion Kernel (h = $(h))"
     test_ADs(FBMKernel; ADs=[:ReverseDiff])
 
-    # Tests failing for ForwardDiff and Zygote.
+    # Tests failing for ForwardDiff and Zygote@0.6 (obtained with Julia > 1.3).
     # Related to: https://github.com/FluxML/Zygote.jl/issues/1036
     @test_broken !isinf(ForwardDiff.gradient(x -> x[1]^x[2], [0.0, 0.9])[1])
-    @test_broken !isinf(
-        Zygote.gradient((x, y) -> sum(f.(x, y)), zeros(1), fill(0.9, 1))[1][1]
-    )
+    if VERSION >= v"1.4.0"
+        f(x, y) = x ^ y
+        @test_broken !isinf(
+            Zygote.gradient((x, y) -> sum(f.(x, y)), zeros(1), fill(0.9, 1))[1][1]
+        )
+    else
+        test_ADs(FBMKernel; ADs=[:Zygote])
+    end
 
     test_params(k, ([h],))
 end

--- a/test/basekernels/fbm.jl
+++ b/test/basekernels/fbm.jl
@@ -19,7 +19,9 @@
     # Tests failing for ForwardDiff and Zygote.
     # Related to: https://github.com/FluxML/Zygote.jl/issues/1036
     @test_broken !isinf(ForwardDiff.gradient(x -> x[1]^x[2], [0.0, 0.9])[1])
-    @test_broken !isinf(Zygote.gradient((x, y) -> sum(f.(x, y)), zeros(1), fill(0.9, 1))[1][1])
+    @test_broken !isinf(
+        Zygote.gradient((x, y) -> sum(f.(x, y)), zeros(1), fill(0.9, 1))[1][1]
+    )
 
     test_params(k, ([h],))
 end


### PR DESCRIPTION
We've been CI failures. I believe I've diagnosed the problem, and have opened an issue about it: https://github.com/FluxML/Zygote.jl/issues/1036

In the mean time, we need our CI to pass, so I've added some tests which are broken, and will be fixed when the issue in question is fixed (so we'll know about it when it happens).