### PR TITLE
Multi-Output helper function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.9"
+version = "0.10.10"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -58,7 +58,12 @@ For an explanation of this design choice, see [the design notes on multi-output 
 An input to a multi-output `Kernel` should be a `Tuple{T, Int}`, whose first element specifies a location in the domain of the multi-output GP, and whose second element specifies which output the inputs corresponds to.
 The type of collections of inputs for multi-output GPs is therefore `AbstractVector{<:Tuple{T, Int}}`.
 
-KernelFunctions.jl provides the following type or situations in which all outputs are observed all of the time:
+KernelFunctions.jl provides the following helper function for situations in which all outputs are observed all of the time:
+```@docs
+prepare_isotopic_multi_output_data
+```
+
+The input types that it constructs can also be constructed manually:
 ```@docs
 MOInput
 ```
@@ -68,7 +73,7 @@ type enables specialised implementations of e.g. [`kernelmatrix`](@ref) for
 
 To find out more about the background, read this [review of kernels for vector-valued functions](https://arxiv.org/pdf/1106.6251.pdf).
 
-## Utilities
+## Generic Utilities
 
 KernelFunctions also provides miscellaneous utility functions.
 ```@docs

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -60,7 +60,8 @@ The type of collections of inputs for multi-output GPs is therefore `AbstractVec
 
 KernelFunctions.jl provides the following helper function for situations in which all outputs are observed all of the time:
 ```@docs
-prepare_isotopic_multi_output_data
+prepare_isotopic_multi_output_data(x::AbstractVector, y::ColVecs)
+prepare_isotopic_multi_output_data(x::AbstractVector, y::RowVecs)
 ```
 
 The input types that it constructs can also be constructed manually:

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -36,7 +36,7 @@ export spectral_mixture_kernel, spectral_mixture_product_kernel
 
 export ColVecs, RowVecs
 
-export MOInput
+export MOInput, prepare_isotopic_multi_output_data
 export IndependentMOKernel,
     LatentFactorMOKernel, IntrinsicCoregionMOKernel, LinearMixingModelKernel
 

--- a/src/mokernels/moinput.jl
+++ b/src/mokernels/moinput.jl
@@ -114,7 +114,7 @@ use with multi-output kernels.
 `y[n]` is the vector-valued output corresponding to the input `x[n]`.
 Consequently, it is necessary that `length(x) == length(y)`.
 
-For example, if outputs are initially stored in a `num_outputs x N` matrix:
+For example, if outputs are initially stored in a `num_outputs × N` matrix:
 ```julia
 julia> x = [1.0, 2.0, 3.0];
 
@@ -159,7 +159,7 @@ use with multi-output kernels.
 `y[n]` is the vector-valued output corresponding to the input `x[n]`.
 Consequently, it is necessary that `length(x) == length(y)`.
 
-For example, if outputs are initial stored in an `N x num_outputs` matrix:
+For example, if outputs are initial stored in an `N × num_outputs` matrix:
 ```jldoctest
 julia> x = [1.0, 2.0, 3.0];
 

--- a/src/mokernels/moinput.jl
+++ b/src/mokernels/moinput.jl
@@ -116,25 +116,32 @@ Consequently, it is necessary that `length(x) == length(y)`.
 
 For example:
 ```julia
-julia> N, P = 10, 5;
+julia> x = [1.0, 2.0, 3.0];
 
-julia> x = randn(N);
+julia> Y = [1.1 2.1 3.1; 1.2 2.2 3.2]
+2×3 Matrix{Float64}:
+ 1.1  2.1  3.1
+ 1.2  2.2  3.2
 
-julia> y = ColVecs(randn(P, N));
+julia> inputs, outputs = prepare_isotopic_multi_output_data(x, ColVecs(Y));
 
-julia> x_canon, y_canon = prepare_isotopic_multi_output_data(x, y);
+julia> inputs
+6-element KernelFunctions.MOInputIsotopicByFeatures{Float64, Vector{Float64}}:
+ (1.0, 1)
+ (1.0, 2)
+ (2.0, 1)
+ (2.0, 2)
+ (3.0, 1)
+ (3.0, 2)
 
-julia> x_canon isa KernelFunctions.MOInputIsotopicByFeatures
-true
-
-julia> length(x_canon) == N * P
-true
-
-julia> y_canon isa AbstractVector{<:Real}
-true
-
-julia> length(y_canon) == length(x_canon)
-true
+julia> outputs
+6-element Vector{Float64}:
+ 1.1
+ 1.2
+ 2.1
+ 2.2
+ 3.1
+ 3.2
 ```
 """
 function prepare_isotopic_multi_output_data(x::AbstractVector, y::ColVecs)
@@ -154,25 +161,33 @@ Consequently, it is necessary that `length(x) == length(y)`.
 
 For example:
 ```jldoctest
-julia> N, P = 10, 5;
+julia> x = [1.0, 2.0, 3.0];
 
-julia> x = randn(N);
+julia> Y = [1.1 1.2; 2.1 2.2; 3.1 3.2]
+3×2 Matrix{Float64}:
+ 1.1  1.2
+ 2.1  2.2
+ 3.1  3.2
 
-julia> y = RowVecs(randn(N, P));
+julia> inputs, outputs = prepare_isotopic_multi_output_data(x, RowVecs(Y));
 
-julia> x_canon, y_canon = prepare_isotopic_multi_output_data(x, y);
+julia> inputs
+6-element KernelFunctions.MOInputIsotopicByOutputs{Float64, Vector{Float64}}:
+ (1.0, 1)
+ (2.0, 1)
+ (3.0, 1)
+ (1.0, 2)
+ (2.0, 2)
+ (3.0, 2)
 
-julia> x_canon isa KernelFunctions.MOInputIsotopicByOutputs
-true
-
-julia> length(x_canon) == N * P
-true
-
-julia> y_canon isa AbstractVector{<:Real}
-true
-
-julia> length(y_canon) == length(x_canon)
-true
+julia> outputs
+6-element Vector{Float64}:
+ 1.1
+ 2.1
+ 3.1
+ 1.2
+ 2.2
+ 3.2
 ```
 """
 function prepare_isotopic_multi_output_data(x::AbstractVector, y::RowVecs)

--- a/src/mokernels/moinput.jl
+++ b/src/mokernels/moinput.jl
@@ -114,7 +114,7 @@ use with multi-output kernels.
 `y[n]` is the vector-valued output corresponding to the input `x[n]`.
 Consequently, it is necessary that `length(x) == length(y)`.
 
-For example:
+For example, if outputs are initially stored in a `num_outputs x N` matrix:
 ```julia
 julia> x = [1.0, 2.0, 3.0];
 
@@ -159,7 +159,7 @@ use with multi-output kernels.
 `y[n]` is the vector-valued output corresponding to the input `x[n]`.
 Consequently, it is necessary that `length(x) == length(y)`.
 
-For example:
+For example, if outputs are initial stored in an `N x num_outputs` matrix:
 ```jldoctest
 julia> x = [1.0, 2.0, 3.0];
 

--- a/src/mokernels/moinput.jl
+++ b/src/mokernels/moinput.jl
@@ -104,7 +104,6 @@ and removed in version 0.12.
 """
 const MOInput = MOInputIsotopicByOutputs
 
-
 """
     prepare_isotopic_multi_output_data(x::AbstractVector, Y::AbstractMatrix{<:Real})
 

--- a/test/mokernels/moinput.jl
+++ b/test/mokernels/moinput.jl
@@ -44,4 +44,35 @@
         @test ibf[7] == (x[3], 1)
         @test all([(x_, i) for x_ in x for i in 1:3] .== ibf)
     end
+
+    @testset "prepare_isotopic_multi_output_data" begin
+        @testset "ColVecs" begin
+            N = 10
+            P = 5
+
+            x = randn(N)
+            y = ColVecs(randn(P, N))
+
+            x_canon, y_canon = prepare_isotopic_multi_output_data(x, y);
+
+            @test x_canon isa KernelFunctions.MOInputIsotopicByFeatures
+            @test length(x_canon) == N * P
+            @test y_canon isa AbstractVector{<:Real}
+            @test length(y_canon) == length(x_canon)
+        end
+        @testset "RowVecs" begin
+            N = 10
+            P = 5
+
+            x = randn(N)
+            y = RowVecs(randn(N, P))
+
+            x_canon, y_canon = prepare_isotopic_multi_output_data(x, y);
+
+            @test x_canon isa KernelFunctions.MOInputIsotopicByOutputs
+            @test length(x_canon) == N * P
+            @test y_canon isa AbstractVector{<:Real}
+            @test length(y_canon) == length(x_canon)
+        end
+    end
 end

--- a/test/mokernels/moinput.jl
+++ b/test/mokernels/moinput.jl
@@ -47,13 +47,13 @@
 
     @testset "prepare_isotopic_multi_output_data" begin
         @testset "ColVecs" begin
-            N = 10
-            P = 5
+            N = 5
+            P = 3
 
             x = randn(N)
             y = ColVecs(randn(P, N))
 
-            x_canon, y_canon = prepare_isotopic_multi_output_data(x, y);
+            x_canon, y_canon = prepare_isotopic_multi_output_data(x, y)
 
             @test x_canon isa KernelFunctions.MOInputIsotopicByFeatures
             @test length(x_canon) == N * P
@@ -61,13 +61,13 @@
             @test length(y_canon) == length(x_canon)
         end
         @testset "RowVecs" begin
-            N = 10
-            P = 5
+            N = 5
+            P = 3
 
             x = randn(N)
             y = RowVecs(randn(N, P))
 
-            x_canon, y_canon = prepare_isotopic_multi_output_data(x, y);
+            x_canon, y_canon = prepare_isotopic_multi_output_data(x, y)
 
             @test x_canon isa KernelFunctions.MOInputIsotopicByOutputs
             @test length(x_canon) == N * P

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -183,8 +183,8 @@ include("test_utils.jl")
                 KernelFunctions;
                 doctestfilters=[
                     r"{([a-zA-Z0-9]+,\s?)+[a-zA-Z0-9]+}",
-                    r"(Array{[a-zA-Z0-9]+,\s?1}|\s?Vector{[a-zA-Z0-9]+})",
-                    r"(Array{[a-zA-Z0-9]+,\s?2}|\s?Matrix{[a-zA-Z0-9]+})",
+                    r"(\s?Array{[a-zA-Z0-9]+,\s?1}|\s?Vector{[a-zA-Z0-9]+})",
+                    r"(\s?Array{[a-zA-Z0-9]+,\s?2}|\s?Matrix{[a-zA-Z0-9]+})",
                 ],
             )
         end


### PR DESCRIPTION
Implements a function to make it possible to work with our input types for multi-output GPs more straightforwardly in the isotopic case.

It's entirely possible that we'll want more helper functions as we move forwards, so this should be seen as a first step in that direction, rather than something that will solve all useability problems.

edit: I've added a note to the docs. Unless I'm missing something obvious, we don't currently have a multi-output example, so I'm not going to create one in this PR to showcase this functionality.

edit2: also note that I'm testing only via doctests. It feels a bit weird, but it's not obviously to me that it's obviously a bad idea, so maybe it's okay?