### PR TITLE
Fixes warnings during REPL startup while using custom SYSIMG's

### DIFF
--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -118,10 +118,10 @@ include("test_utils.jl")
 
 function __init__()
     @require Kronecker = "2c470bb0-bcc8-11e8-3dad-c9649493f05e" begin
-        include(joinpath("matrix", "kernelkroneckermat.jl"))
+        Requires.@include("matrix/kernelkroneckermat.jl")
     end
     @require PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150" begin
-        include(joinpath("matrix", "kernelpdmat.jl"))
+        Requires.@include("matrix/kernelpdmat.jl")
     end
 end
 


### PR DESCRIPTION
We encounter following warning during Julia REPL startup if we include `KernelFunctions` in the default SYSIMG, this commit fixes that issue

```
┌ Warning: Error requiring `PDMats` from `KernelFunctions`
│   exception =
│    SystemError: opening file "/home/bmharsha/.julia/packages/KernelFunctions/AxuTC/src/matrix/kernelpdmat.jl": No such file or directory
│    Stacktrace:
│      [1] systemerror(p::String, errno::Int32; extrainfo::Nothing)
│        @ Base ./error.jl:168
│      [2] #systemerror#62
│        @ ./error.jl:167 [inlined]
│      [3] systemerror
│        @ ./error.jl:167 [inlined]
│      [4] open(fname::String; lock::Bool, read::Nothing, write::Nothing, create::Nothing, truncate::Nothing, append::Nothing)
│        @ Base ./iostream.jl:293
│      [5] open
│        @ ./iostream.jl:282 [inlined]
│      [6] open(f::Base.var"#326#327"{String}, args::String; kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
│        @ Base ./io.jl:328
│      [7] open
│        @ ./io.jl:328 [inlined]
│      [8] read
│        @ ./io.jl:434 [inlined]
│      [9] _include(mapexpr::Function, mod::Module, _path::String)
│        @ Base ./loading.jl:1166
│     [10] include(mod::Module, _path::String)
│        @ Base ./Base.jl:386
│     [11] include(x::String)
│        @ KernelFunctions ~/.julia/packages/KernelFunctions/AxuTC/src/KernelFunctions.jl:1
│     [12] top-level scope
│        @ ~/.julia/packages/KernelFunctions/AxuTC/src/KernelFunctions.jl:124
│     [13] eval
│        @ ./boot.jl:360 [inlined]
│     [14] eval
│        @ ~/.julia/packages/KernelFunctions/AxuTC/src/KernelFunctions.jl:1 [inlined]
│     [15] (::KernelFunctions.var"#209#215")()
│        @ KernelFunctions ~/.julia/packages/Requires/7Ncym/src/require.jl:99
│     [16] err(f::Any, listener::Module, modname::String)
│        @ Requires ~/.julia/packages/Requires/7Ncym/src/require.jl:47
│     [17] (::KernelFunctions.var"#208#214")()
│        @ KernelFunctions ~/.julia/packages/Requires/7Ncym/src/require.jl:98
│     [18] withpath(f::Any, path::String)
│        @ Requires ~/.julia/packages/Requires/7Ncym/src/require.jl:37
│     [19] (::KernelFunctions.var"#207#213")()
│        @ KernelFunctions ~/.julia/packages/Requires/7Ncym/src/require.jl:97
│     [20] listenpkg(f::Any, pkg::Base.PkgId)
│        @ Requires ~/.julia/packages/Requires/7Ncym/src/require.jl:20
│     [21] macro expansion
│        @ ~/.julia/packages/Requires/7Ncym/src/require.jl:95 [inlined]
│     [22] __init__()
│        @ KernelFunctions ~/.julia/packages/KernelFunctions/AxuTC/src/KernelFunctions.jl:123
└ @ Requires ~/.julia/packages/Requires/7Ncym/src/require.jl:49
```