### PR TITLE
Qualify pairwise call

### DIFF
--- a/test/utils.jl
+++ b/test/utils.jl
@@ -98,12 +98,38 @@
         x_rowvecs = RowVecs(randn(7, 3))
 
         @test isapprox(
-            pairwise(SqEuclidean(), x_colvecs, x_rowvecs),
-            pairwise(SqEuclidean(), collect(x_colvecs), collect(x_rowvecs)),
+            KernelFunctions.pairwise(SqEuclidean(), x_colvecs, x_rowvecs),
+            KernelFunctions.pairwise(SqEuclidean(), collect(x_colvecs), collect(x_rowvecs)),
         )
         @test isapprox(
             pairwise(SqEuclidean(), x_rowvecs, x_colvecs),
             pairwise(SqEuclidean(), collect(x_rowvecs), collect(x_colvecs)),
+        )
+    end
+    @testset "AbstractVector + RowVecs" begin
+        x = [randn(3) for _ in 1:5]
+        x_rowvecs = RowVecs(randn(7, 3))
+    
+        @test isapprox(
+            KernelFunctions.pairwise(SqEuclidean(), x, x_rowvecs),
+            pairwise(SqEuclidean(), x, collect(x_rowvecs)),
+        )
+        @test isapprox(
+            KernelFunctions.pairwise(SqEuclidean(), x_rowvecs, x),
+            pairwise(SqEuclidean(), collect(x_rowvecs), x),
+        )
+    end
+    @testset "AbstractVector + ColVecs" begin
+        x = [randn(3) for _ in 1:5]
+        x_colvecs = ColVecs(randn(3, 7))
+    
+        @test isapprox(
+            KernelFunctions.pairwise(SqEuclidean(), x, x_colvecs),
+            pairwise(SqEuclidean(), x, collect(x_colvecs)),
+        )
+        @test isapprox(
+            KernelFunctions.pairwise(SqEuclidean(), x_colvecs, x),
+            pairwise(SqEuclidean(), collect(x_colvecs), x),
         )
     end
     @testset "input checks" begin


### PR DESCRIPTION
While trying to understand how to work with Coverage I was struck by some lines that stubbornly did not get covered. Initially I thought that was due to missing tests, but even adding those did not change the coverage. 

After some effort, I have found that these functions don't get called because the default `Distances.pairwise` is already enough. I managed to get those lines covered by qualifying the `pairwise` call in the tests, but it seems they are not actually necessary? Maybe it makes sense to remove those definitions from src altogether?