### PR TITLE
Add lazy kronecker product for matrix kernels, if Kronecker.jl is loaded

### DIFF
--- a/src/matrix/kernelkroneckermat.jl
+++ b/src/matrix/kernelkroneckermat.jl
@@ -26,10 +26,6 @@ end
 """
 @inline iskroncompatible(κ::Kernel) = false # Default return for kernels
 
-@inline ismatrixkroncompatible(κ::MOKernel) = false # Default return for kernels
-@inline ismatrixkroncompatible(κ::IndependentMOKernel) = true
-@inline ismatrixkroncompatible(κ::IntrinsicCoregionMOKernel) = true
-
 function _kernelmatrix_kroneckerjl_helper(::MOInputIsotopicByFeatures, Kfeatures, Koutputs)
     return Kronecker.kronecker(Kfeatures, Koutputs)
 end

--- a/src/matrix/kernelkroneckermat.jl
+++ b/src/matrix/kernelkroneckermat.jl
@@ -25,3 +25,37 @@ end
     k(x,x') = ∏ᵢᴰ k(xᵢ,x'ᵢ)
 """
 @inline iskroncompatible(κ::Kernel) = false # Default return for kernels
+
+@inline ismatrixkroncompatible(κ::MOKernel) = false # Default return for kernels
+@inline ismatrixkroncompatible(κ::IndependentMOKernel) = true
+@inline ismatrixkroncompatible(κ::IntrinsicCoregionMOKernel) = true
+
+function _mo_kernelmatrix_kron(::MOInputIsotopicByFeatures, K, B)
+    return Kronecker.kronecker(K, B)
+end
+
+function _mo_kernelmatrix_kron(::MOInputIsotopicByOutputs, K, B)
+    return Kronecker.kronecker(B, K)
+end
+
+function kernelkronmat(
+    k::IndependentMOKernel, x::MOI, y::MOI
+) where {MOI<:IsotopicMOInputsUnion}
+    @assert x.out_dim == y.out_dim
+    Ktmp = kernelmatrix(k.kernel, x.x, y.x)
+    mtype = eltype(Ktmp)
+    return _mo_kernelmatrix_kron(Ktmp, Eye{mtype}(x.out_dim), x)
+end
+
+function kernelkronmat(
+    k::IntrinsicCoregionMOKernel, x::MOI, y::MOI
+) where {MOI<:IsotopicMOInputsUnion}
+    @assert x.out_dim == y.out_dim
+    Ktmp = kernelmatrix(k.kernel, x.x, y.x)
+    return _mo_kernelmatrix_kron(Ktmp, k.B, x)
+end
+
+function kernelkronmat(k::MOK, x::MOI) where {MOI<:IsotopicMOInputsUnion,MOK<:MOKernel}
+    @assert ismatrixkroncompatible(κ) "The chosen kernel is not compatible for Kronecker matrices"
+    return kernelkronmat(k, x, x)
+end


### PR DESCRIPTION
**Summary**
Following #354 this PR adds lazy Kronecker products for the `IndependentMOKernel` and the `IntrinsicCoregionMOKernel` via an optional dependency on Kronecker.jl. Also includes comments and thoughts from the previous PR. 

**Proposed changes**
- Add lazy `kronecker_kernelmatrix`

**What alternatives have you considered?**
The name for `kronecker_kernelmatrix` is perhaps not ideal, maybe an additional `mo` suffix/prefix is needed. I think conflating this with `kernelkronmat` would be confusing.  

I have also considered making the `_mo_output_covariance` function apply also for the regular `kernelmatrix`, but this may cause conflicts with #363 , and would have to be done once both are resolved. 

**Breaking changes**
None. 
