### PR TITLE
add gibbskernel example to prior example script

### DIFF
--- a/examples/gaussian-process-priors/script.jl
+++ b/examples/gaussian-process-priors/script.jl
@@ -120,6 +120,7 @@ kernels = [
     LinearKernel(),
     compose(PeriodicKernel(), ScaleTransform(0.2)),
     NeuralNetworkKernel(),
+    GibbsKernel(x -> exp(sin.(x))),
 ]
 plot(
     [visualize(k) for k in kernels]...;


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
<!-- Summary of what & why - explain your motivation and/or link to any GitHub issues this relates to -->

Adding an example how to use the Gibbs Kernel in the prior example.
The Gibbs kernel has a lengthscale *function* as it's parameter.
I just chose a simple function for demonstration purposes i.e. `l(x) = exp(sin(x))`.

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
* Adding an example to `examples/gaussian-process-priors/script.jl`

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

Could make a separate example and will probably do that when I have a working version of the Gibbs kernel that also learns the lengthscale function.

**Breaking changes**
<!-- If this PR breaks backwards-compatibility, please start the PR title with `**BREAKING**`! -->
<!-- In this section, describe any changes that are not backwards-compatible, -->
<!-- why it is worth breaking backwards compatiblity, -->
<!-- and how a user would have to address these changes in their downstream code. -->

None