### PR TITLE
Implement Zygote hack

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.21"
+version = "0.10.22"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -60,6 +60,10 @@ using StatsBase
 using TensorCore
 using ZygoteRules: ZygoteRules
 
+# Hack to work around Zygote type inference problems.
+const Distances_pairwise = Distances.pairwise
+
+
 abstract type Kernel end
 abstract type SimpleKernel <: Kernel end
 

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -63,7 +63,6 @@ using ZygoteRules: ZygoteRules
 # Hack to work around Zygote type inference problems.
 const Distances_pairwise = Distances.pairwise
 
-
 abstract type Kernel end
 abstract type SimpleKernel <: Kernel end
 

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -58,7 +58,7 @@ using IrrationalConstants: logtwo, twoπ, invsqrt2
 using LogExpFunctions: softplus
 using StatsBase
 using TensorCore
-using ZygoteRules: ZygoteRules
+using ZygoteRules: ZygoteRules, AContext, literal_getproperty, literal_getfield
 
 # Hack to work around Zygote type inference problems.
 const Distances_pairwise = Distances.pairwise

--- a/src/distances/pairwise.jl
+++ b/src/distances/pairwise.jl
@@ -13,11 +13,11 @@ end
 pairwise!(out::AbstractMatrix, d::PreMetric, X::AbstractVector) = pairwise!(out, d, X, X)
 
 function pairwise(d::PreMetric, x::AbstractVector{<:Real})
-    return Distances.pairwise(d, reshape(x, :, 1); dims=1)
+    return Distances_pairwise(d, reshape(x, :, 1); dims=1)
 end
 
 function pairwise(d::PreMetric, x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
-    return Distances.pairwise(d, reshape(x, :, 1), reshape(y, :, 1); dims=1)
+    return Distances_pairwise(d, reshape(x, :, 1), reshape(y, :, 1); dims=1)
 end
 
 function pairwise!(out::AbstractMatrix, d::PreMetric, x::AbstractVector{<:Real})

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -80,8 +80,6 @@ Base.vcat(a::ColVecs, b::ColVecs) = ColVecs(hcat(a.X, b.X))
 
 dim(x::ColVecs) = size(x.X, 1)
 
-const Distances_pairwise = Distances.pairwise
-
 pairwise(d::PreMetric, x::ColVecs) = Distances_pairwise(d, x.X; dims=2)
 pairwise(d::PreMetric, x::ColVecs, y::ColVecs) = Distances_pairwise(d, x.X, y.X; dims=2)
 function pairwise(d::PreMetric, x::AbstractVector, y::ColVecs)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -80,13 +80,15 @@ Base.vcat(a::ColVecs, b::ColVecs) = ColVecs(hcat(a.X, b.X))
 
 dim(x::ColVecs) = size(x.X, 1)
 
-pairwise(d::PreMetric, x::ColVecs) = Distances.pairwise(d, x.X; dims=2)
-pairwise(d::PreMetric, x::ColVecs, y::ColVecs) = Distances.pairwise(d, x.X, y.X; dims=2)
+const Distances_pairwise = Distances.pairwise
+
+pairwise(d::PreMetric, x::ColVecs) = Distances_pairwise(d, x.X; dims=2)
+pairwise(d::PreMetric, x::ColVecs, y::ColVecs) = Distances_pairwise(d, x.X, y.X; dims=2)
 function pairwise(d::PreMetric, x::AbstractVector, y::ColVecs)
-    return Distances.pairwise(d, reduce(hcat, x), y.X; dims=2)
+    return Distances_pairwise(d, reduce(hcat, x), y.X; dims=2)
 end
 function pairwise(d::PreMetric, x::ColVecs, y::AbstractVector)
-    return Distances.pairwise(d, x.X, reduce(hcat, y); dims=2)
+    return Distances_pairwise(d, x.X, reduce(hcat, y); dims=2)
 end
 function pairwise!(out::AbstractMatrix, d::PreMetric, x::ColVecs)
     return Distances.pairwise!(out, d, x.X; dims=2)
@@ -150,13 +152,13 @@ Base.vcat(a::RowVecs, b::RowVecs) = RowVecs(vcat(a.X, b.X))
 
 dim(x::RowVecs) = size(x.X, 2)
 
-pairwise(d::PreMetric, x::RowVecs) = Distances.pairwise(d, x.X; dims=1)
-pairwise(d::PreMetric, x::RowVecs, y::RowVecs) = Distances.pairwise(d, x.X, y.X; dims=1)
+pairwise(d::PreMetric, x::RowVecs) = Distances_pairwise(d, x.X; dims=1)
+pairwise(d::PreMetric, x::RowVecs, y::RowVecs) = Distances_pairwise(d, x.X, y.X; dims=1)
 function pairwise(d::PreMetric, x::AbstractVector, y::RowVecs)
-    return Distances.pairwise(d, permutedims(reduce(hcat, x)), y.X; dims=1)
+    return Distances_pairwise(d, permutedims(reduce(hcat, x)), y.X; dims=1)
 end
 function pairwise(d::PreMetric, x::RowVecs, y::AbstractVector)
-    return Distances.pairwise(d, x.X, permutedims(reduce(hcat, y)); dims=1)
+    return Distances_pairwise(d, x.X, permutedims(reduce(hcat, y)); dims=1)
 end
 function pairwise!(out::AbstractMatrix, d::PreMetric, x::RowVecs)
     return Distances.pairwise!(out, d, x.X; dims=1)

--- a/src/zygoterules.jl
+++ b/src/zygoterules.jl
@@ -5,3 +5,9 @@ end
 ZygoteRules.@adjoint function Base.map(t::Transform, X::RowVecs)
     return ZygoteRules.pullback(_map, t, X)
 end
+
+function ZygoteRules._pullback(
+    cx::AContext, ::typeof(literal_getproperty), x::ColVecs, ::Val{f}
+) where {f}
+    return ZygoteRules._pullback(cx, literal_getfield, x, Val{f}())
+end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -31,7 +31,6 @@ end
 
 # AD utilities
 
-
 # Type to work around some performance issues that can happen on the reverse-pass of Zygote.
 using Zygote: @adjoint, accum, AContext
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -32,8 +32,6 @@ end
 # AD utilities
 
 # Type to work around some performance issues that can happen on the reverse-pass of Zygote.
-using Zygote: @adjoint, accum, AContext
-
 # This context doesn't allow any globals. Don't use this if you use globals in your
 # programme.
 struct NoContext <: Zygote.AContext end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -38,7 +38,7 @@ using Zygote: @adjoint, accum, AContext
 # programme.
 struct NoContext <: Zygote.AContext end
 
-Zygote.cache(cx::NoContext) = (cache_fields=nothing)
+Zygote.cache(cx::NoContext) = (cache_fields = nothing)
 Base.haskey(cx::NoContext, x) = false
 Zygote.accum_param(::NoContext, x, Δ) = Δ
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -42,7 +42,6 @@ Zygote.cache(cx::NoContext) = (cache_fields=nothing)
 Base.haskey(cx::NoContext, x) = false
 Zygote.accum_param(::NoContext, x, Δ) = Δ
 
-
 const FDM = FiniteDifferences.central_fdm(5, 1)
 
 gradient(f, s::Symbol, args) = gradient(f, Val(s), args)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -52,18 +52,20 @@
             @test back(ones(size(X)))[1].X == ones(size(X))
         end
 
-        @testset "Zygote type-inference" begin
-            ctx = NoContext()
-            x = ColVecs(randn(2, 4))
-            y = ColVecs(randn(2, 3))
+        if VERSION >= v"1.6"
+            @testset "Zygote type-inference" begin
+                ctx = NoContext()
+                x = ColVecs(randn(2, 4))
+                y = ColVecs(randn(2, 3))
 
-            # Ensure KernelFunctions.pairwise rather than Distances.pairwise is used.
-            check_zygote_type_stability(
-                x -> KernelFunctions.pairwise(SqEuclidean(), x), x; ctx=ctx
-            )
-            check_zygote_type_stability(
-                (x, y) -> KernelFunctions.pairwise(SqEuclidean(), x, y), x, y; ctx=ctx
-            )
+                # Ensure KernelFunctions.pairwise rather than Distances.pairwise is used.
+                check_zygote_type_stability(
+                    x -> KernelFunctions.pairwise(SqEuclidean(), x), x; ctx=ctx
+                )
+                check_zygote_type_stability(
+                    (x, y) -> KernelFunctions.pairwise(SqEuclidean(), x, y), x, y; ctx=ctx
+                )
+            end
         end
     end
     @testset "RowVecs" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -51,6 +51,21 @@
             X_, back = Zygote.pullback(DX -> DX.X, DX)
             @test back(ones(size(X)))[1].X == ones(size(X))
         end
+
+        @testset "Zygote type-inference" begin
+            ctx = NoContext()
+            x = ColVecs(randn(2, 4))
+            y = ColVecs(randn(2, 3))
+
+            # Why on earth I need to write KernelFunctions.pairwise, rather than just
+            # pairwise, is beyond me. Probably something to do with globals or something.
+            check_zygote_type_stability(
+                x -> KernelFunctions.pairwise(SqEuclidean(), x), x; ctx=ctx
+            )
+            check_zygote_type_stability(
+                (x, y) -> KernelFunctions.pairwise(SqEuclidean(), x, y), x, y; ctx=ctx
+            )
+        end
     end
     @testset "RowVecs" begin
         DX = RowVecs(X)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -57,8 +57,7 @@
             x = ColVecs(randn(2, 4))
             y = ColVecs(randn(2, 3))
 
-            # Why on earth I need to write KernelFunctions.pairwise, rather than just
-            # pairwise, is beyond me. Probably something to do with globals or something.
+            # Ensure KernelFunctions.pairwise rather than Distances.pairwise is used.
             check_zygote_type_stability(
                 x -> KernelFunctions.pairwise(SqEuclidean(), x), x; ctx=ctx
             )


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
<!-- Summary of what & why - explain your motivation and/or link to any GitHub issues this relates to -->
Zygote has type-stability issues associated with getfield and getproperty. Hopefully we'll get a solution at some point (see e.g. [this PR](https://github.com/FluxML/Zygote.jl/pull/909/files)), but in the mean time, avoiding the`getproperty` call here occassionally removes a type-stability problem.

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->
Write `Distances_pairwise` instead of `Distances.pairwise`.

<!-- A clear and concise description of the contents of this pull request. -->

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
Ideally we wouldn't have our own version of this function, so I thought about trying to solve that properly. Seemed like this proposed solution is easiest, doesn't break anything, and works now.

**Breaking changes**
<!-- If this PR breaks backwards-compatibility, please start the PR title with `**BREAKING**`! -->
<!-- In this section, describe any changes that are not backwards-compatible, -->
<!-- why it is worth breaking backwards compatiblity, -->
<!-- and how a user would have to address these changes in their downstream code. -->
None