### PR TITLE
Add `InverseMultiquadricKernel`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.26"
+version = "0.10.27"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/KernelFunctions.jl
+++ b/src/KernelFunctions.jl
@@ -13,6 +13,7 @@ export FBMKernel
 export MaternKernel, Matern12Kernel, Matern32Kernel, Matern52Kernel
 export LinearKernel, PolynomialKernel
 export RationalKernel, RationalQuadraticKernel, GammaRationalKernel
+export InverseMultiQuadricKernel
 export PiecewisePolynomialKernel
 export PeriodicKernel, NeuralNetworkKernel
 export KernelSum, KernelProduct, KernelTensorProduct


### PR DESCRIPTION
This PR adds the inverse multiquadric kernel
```math
k(x, x'; alpha, c) = (c + d(x, x')^2)^(- alpha)
```
with parameters `alpha, c > 0`.

In recent years, in particular in the ML community (possibly due to https://arxiv.org/abs/1711.01558) this kernel or some special cases (e.g. with `alpha = 1/2` and `c = 1`: http://proceedings.mlr.press/v119/delbridge20a/delbridge20a.pdf) are called "inverse multiquadratic kernel". As far as I know, however, the traditional name is "inverse multiquadric kernel" (see e.g. Schölkopf and Smola's "Learning with Kernels").