### PR TITLE
Add `with_period` convenience function and a example to `PeriodicTransform` docstring

### DIFF
--- a/src/transform/periodic_transform.jl
+++ b/src/transform/periodic_transform.jl
@@ -14,6 +14,21 @@ julia> f = rand(); t = PeriodicTransform(f); x = rand();
 julia> t(x) == [sinpi(2 * f * x), cospi(2 * f * x)]
 true
 ```
+
+For 1 dimensional inputs it is possible to create a kernel equivalent
+to the `PeriodicKernel` using `PeriodicTransform` and a
+`SqExponentialKernel`.
+
+```jldoctest
+julia> wiggle_scale = 0.5; period = π/2; x = rand(); y = rand();
+
+julia> k1 = with_lengthscale(PeriodicKernel(; r=[wiggle_scale / 2]), period);
+
+julia> k2 = with_lengthscale(SqExponentialKernel(), wiggle_scale) ∘ PeriodicTransform(1/period)
+
+julia> k1(x,y) ≈ k2(x,y)
+true
+```
 """
 struct PeriodicTransform{Tf<:AbstractVector{<:Real}} <: Transform
     f::Tf

--- a/src/transform/with_period.jl
+++ b/src/transform/with_period.jl
@@ -1,0 +1,21 @@
+"""
+    with_period(kernel::Kernel, period::Real)
+
+Construct a transformed kernel with `period`.
+
+# Examples
+
+```jldoctest
+julia> kernel = with_period(SqExponentialKernel(), π/2);
+
+julia> x = rand();
+
+julia> y = rand();
+
+julia> kernel(x, y) ≈ (SqExponentialKernel() ∘ PeriodicTransform(2/π))(x, y)
+true
+```
+"""
+function with_period(kernel::Kernel, period::Real)
+    return kernel ∘ PeriodicTransform(inv(period))
+end


### PR DESCRIPTION
This PR follows the suggestion [in this comment](https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/issues/389#issuecomment-961956874
)
As it is  `with_period` only works with scalars, which contrasts with `with_lengthscale` that uses `ARDTransform` to deal with vector inputs. Any ideas on how should we deal with this? 
