### PR TITLE
first go at extending the GibbsKernel to work with other base kernels

### DIFF
--- a/src/kernels/gibbskernel.jl
+++ b/src/kernels/gibbskernel.jl
@@ -36,11 +36,11 @@ end
 
 GibbsKernel(; lengthscale) = GibbsKernel(lengthscale)
 
-function (k::GibbsKernel)(x, y)
+function (k::GibbsKernel)(x, y, base_kernel::Kernel=SqExponentialKernel)
     lengthscale = k.lengthscale
     lx = lengthscale(x)
     ly = lengthscale(y)
     l = invsqrt2 * hypot(lx, ly)
-    kernel = (sqrt(lx * ly) / l) * with_lengthscale(SqExponentialKernel(), l)
+    kernel = (sqrt(lx * ly) / l) * with_lengthscale(base_kernel(), l)
     return kernel(x, y)
 end


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
@st-- in issue https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/issues/372 suggested modifying the GibbsKernel to take as an argument a base kernel function.

This is a first cut at trying to implement this to get the conversation going. I'm sure I haven't implemented it correctly and I have changed any docstrings yet.

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
* adding a new function argument `base_kernel` which is by default the `SqExponentialKernel`. 

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Breaking changes**
<!-- If this PR breaks backwards-compatibility, please start the PR title with `**BREAKING**`! -->
<!-- In this section, describe any changes that are not backwards-compatible, -->
<!-- why it is worth breaking backwards compatiblity, -->
<!-- and how a user would have to address these changes in their downstream code. -->
