### PR TITLE
Zygote AD failure workarounds & test cleanup

### DIFF
--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -280,6 +280,9 @@ function test_AD(AD::Symbol, kernelfunction, args=nothing, dims=[3, 3])
                     compare_gradient(AD, args) do p
                         testfunction(kernelfunction(p), A, dim)
                     end
+                    compare_gradient(AD, args) do p
+                        testfunction(kernelfunction(p), A, B, dim)
+                    end
                 end
 
                 compare_gradient(AD, A) do a
@@ -294,6 +297,9 @@ function test_AD(AD::Symbol, kernelfunction, args=nothing, dims=[3, 3])
                 if args !== nothing
                     compare_gradient(AD, args) do p
                         testdiagfunction(kernelfunction(p), A, dim)
+                    end
+                    compare_gradient(AD, args) do p
+                        testdiagfunction(kernelfunction(p), A, B, dim)
                     end
                 end
             end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -226,7 +226,6 @@ function test_AD(AD::Symbol, kernelfunction, args=nothing, dims=[3, 3])
                 end
             end
         end # kernel matrices
-
     end
 end
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -100,7 +100,7 @@ function check_zygote_type_stability(f, args...; ctx=Zygote.Context())
     @inferred f(args...)
     @inferred Zygote._pullback(ctx, f, args...)
     out, pb = Zygote._pullback(ctx, f, args...)
-    @test_throws ErrorException @inferred pb(out)
+    @inferred pb(out)
 end
 
 function test_ADs(

--- a/test/transform/chaintransform.jl
+++ b/test/transform/chaintransform.jl
@@ -25,7 +25,7 @@
     test_ADs(
         x -> SEKernel() ∘ (ScaleTransform(exp(x[1])) ∘ ARDTransform(exp.(x[2:4]))),
         randn(rng, 4);
-        ADs=[:ForwardDiff, :ReverseDiff]
+        ADs=[:ForwardDiff, :ReverseDiff]  # explicitly pass ADs to exclude :Zygote
     )
-    @test_broken "test_AD of chain transform is currently broken in Zygote"
+    @test_broken "test_AD of chain transform is currently broken in Zygote, see GitHub issue #263"
 end

--- a/test/transform/chaintransform.jl
+++ b/test/transform/chaintransform.jl
@@ -24,6 +24,8 @@
     @test repr(tp ∘ tf) == "Chain of 2 transforms:\n\t - $(tf) |> $(tp)"
     test_ADs(
         x -> SEKernel() ∘ (ScaleTransform(exp(x[1])) ∘ ARDTransform(exp.(x[2:4]))),
-        randn(rng, 4),
+        randn(rng, 4);
+        ADs=[:ForwardDiff, :ReverseDiff]
     )
+    @test_broken "test_AD of chain transform is currently broken in Zygote"
 end


### PR DESCRIPTION
Zygote seems to have changed again and we now need to revert #409 

Edit: there is now a new AD failure in the select transform (#415), so temporarily disabled that test case.

In the process of trying (and failing) to figure out what's going on, I noticed that there was a lot of code duplication in test/test_utils which I've removed here (left comments to explain what I changed).