### PR TITLE
Deprecate implicit `obsdim` keyword argument

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.27"
+version = "0.10.28"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.28"
+version = "0.10.29"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -139,11 +139,9 @@ In short: many people like matrices, and are familiar with `obsdim`-style keywor
 arguments.
 
 All internals are implemented using `AbstractVector`s though, and the `obsdim` interface
-is just a thin layer of utility functionality which sits on top of this.
-
-
-
-
+is just a thin layer of utility functionality which sits on top of this. To avoid
+confusion and silent errors, we do not favour a specific convention (rows or columns)
+but instead it is necessary to specify the `obsdim` keyword argument explicitly.
 
 ## [Kernels for Multiple-Outputs](@id inputs_for_multiple_outputs)
 

--- a/src/approximations/nystrom.jl
+++ b/src/approximations/nystrom.jl
@@ -9,7 +9,7 @@ function sampleindex(X::AbstractVector, r::Real)
     return S
 end
 
-function nystrom_sample(k::Kernel, X::AbstractVector, S::Vector{<:Integer})
+function nystrom_sample(k::Kernel, X::AbstractVector, S::AbstractVector{<:Integer})
     C = kernelmatrix(k, X[S], X)
     Cs = C[:, S]
     return (C, Cs)

--- a/src/approximations/nystrom.jl
+++ b/src/approximations/nystrom.jl
@@ -9,9 +9,7 @@ function sampleindex(X::AbstractVector, r::Real)
     return S
 end
 
-function nystrom_sample(
-    k::Kernel, X::AbstractVector, S::Vector{<:Integer}
-)
+function nystrom_sample(k::Kernel, X::AbstractVector, S::Vector{<:Integer})
     C = kernelmatrix(k, X[S], X)
     Cs = C[:, S]
     return (C, Cs)
@@ -84,7 +82,12 @@ If `obsdim=2`, equivalent to `nystrom(k, ColVecs(X), S)`.
 
 See also: [`ColVecs`](@ref), [`RowVecs`](@ref)
 """
-function nystrom(k::Kernel, X::AbstractMatrix, S::AbstractVector{<:Integer}; obsdim::Union{Int,Nothing}=defaultobs)
+function nystrom(
+    k::Kernel,
+    X::AbstractMatrix,
+    S::AbstractVector{<:Integer};
+    obsdim::Union{Int,Nothing}=defaultobs,
+)
     return nystrom(k, vec_of_vecs(X; obsdim=obsdim), S)
 end
 

--- a/src/approximations/nystrom.jl
+++ b/src/approximations/nystrom.jl
@@ -1,21 +1,18 @@
 # Following the algorithm by William and Seeger, 2001
 # Cs is equivalent to X_mm and C to X_mn
 
-function sampleindex(X::AbstractMatrix, r::Real; obsdim::Integer=defaultobs)
+function sampleindex(X::AbstractVector, r::Real)
     0 < r <= 1 || throw(ArgumentError("Sample rate `r` must be in range (0,1]"))
-    n = size(X, obsdim)
+    n = length(X)
     m = ceil(Int, n * r)
     S = StatsBase.sample(1:n, m; replace=false, ordered=true)
     return S
 end
 
 function nystrom_sample(
-    k::Kernel, X::AbstractMatrix, S::Vector{<:Integer}; obsdim::Integer=defaultobs
+    k::Kernel, X::AbstractVector, S::Vector{<:Integer}
 )
-    obsdim ∈ [1, 2] ||
-        throw(ArgumentError("`obsdim` should be 1 or 2 (see docs of kernelmatrix))"))
-    Xₘ = obsdim == 1 ? X[S, :] : X[:, S]
-    C = kernelmatrix(k, Xₘ, X; obsdim=obsdim)
+    C = kernelmatrix(k, X[S], X)
     Cs = C[:, S]
     return (C, Cs)
 end
@@ -63,34 +60,60 @@ function NystromFact(W::Matrix{<:Real}, C::Matrix{<:Real})
 end
 
 @doc raw"""
-    nystrom(k::Kernel, X::Matrix, S::Vector; obsdim::Int=defaultobs)
+    nystrom(k::Kernel, X::AbstractVector, S::AbstractVector{<:Integer})
 
-Computes a factorization of Nystrom approximation of the square kernel matrix of data
-matrix `X` with respect to kernel `k`. Returns a `NystromFact` struct which stores a
-Nystrom factorization satisfying:
-```math
-\mathbf{K} \approx \mathbf{C}^{\intercal}\mathbf{W}\mathbf{C}
-```
-"""
-function nystrom(k::Kernel, X::AbstractMatrix, S::Vector{<:Integer}; obsdim::Int=defaultobs)
-    C, Cs = nystrom_sample(k, X, S; obsdim=obsdim)
-    W = nystrom_pinv!(Cs)
-    return NystromFact(W, C)
-end
+Compute a factorization of Nystrom approximation of the square kernel matrix of data `X`
+with respect to kernel `k`.
 
-@doc raw"""
-    nystrom(k::Kernel, X::Matrix, r::Real; obsdim::Int=defaultobs)
-
-Computes a factorization of Nystrom approximation of the square kernel matrix of data
-matrix `X` with respect to kernel `k` using a sample ratio of `r`.
 Returns a `NystromFact` struct which stores a Nystrom factorization satisfying:
 ```math
 \mathbf{K} \approx \mathbf{C}^{\intercal}\mathbf{W}\mathbf{C}
 ```
 """
-function nystrom(k::Kernel, X::AbstractMatrix, r::Real; obsdim::Int=defaultobs)
-    S = sampleindex(X, r; obsdim=obsdim)
-    return nystrom(k, X, S; obsdim=obsdim)
+function nystrom(k::Kernel, X::AbstractVector, S::AbstractVector{<:Integer})
+    C, Cs = nystrom_sample(k, X, S)
+    W = nystrom_pinv!(Cs)
+    return NystromFact(W, C)
+end
+
+"""
+    nystrom(k::Kernel, X::AbstractMatrix, S::AbstractVector{<:Integer}; obsdim)
+
+If `obsdim=1`, equivalent to `nystrom(k, RowVecs(X), S)`.
+If `obsdim=2`, equivalent to `nystrom(k, ColVecs(X), S)`.
+
+See also: [`ColVecs`](@ref), [`RowVecs`](@ref)
+"""
+function nystrom(k::Kernel, X::AbstractMatrix, S::AbstractVector{<:Integer}; obsdim::Union{Int,Nothing}=defaultobs)
+    return nystrom(k, vec_of_vecs(X; obsdim=obsdim), S)
+end
+
+@doc raw"""
+    nystrom(k::Kernel, X::AbstractVector, r::Real)
+
+Compute a factorization of Nystrom approximation of the square kernel matrix of data `X`
+with respect to kernel `k` using a sample ratio of `r`.
+
+Returns a `NystromFact` struct which stores a Nystrom factorization satisfying:
+```math
+\mathbf{K} \approx \mathbf{C}^{\intercal}\mathbf{W}\mathbf{C}
+```
+"""
+function nystrom(k::Kernel, X::AbstractVector, r::Real)
+    S = sampleindex(X, r)
+    return nystrom(k, X, S)
+end
+
+"""
+    nystrom(k::Kernel, X::AbstractMatrix, r::Real; obsdim)
+
+If `obsdim=1`, equivalent to `nystrom(k, RowVecs(X), r)`.
+If `obsdim=2`, equivalent to `nystrom(k, ColVecs(X), r)`.
+
+See also: [`ColVecs`](@ref), [`RowVecs`](@ref)
+"""
+function nystrom(k::Kernel, X::AbstractMatrix, r::Real; obsdim::Union{Int,Nothing}=nothing)
+    return nystrom(k, vec_of_vecs(X; obsdim=obsdim), r)
 end
 
 """

--- a/src/approximations/nystrom.jl
+++ b/src/approximations/nystrom.jl
@@ -9,9 +9,9 @@ function sampleindex(X::AbstractVector, r::Real)
     return S
 end
 
-@deprecate sampleindex(X::AbstractMatrix, r::Real; obsdim::Union{Integer,Nothing}=defaultobs) sampleindex(
-    vec_of_vecs(X; obsdim=obsdim===nothing ? nothing : Int(obsdim)), r
-) false
+@deprecate sampleindex(
+    X::AbstractMatrix, r::Real; obsdim::Union{Integer,Nothing}=defaultobs
+) sampleindex(vec_of_vecs(X; obsdim=obsdim === nothing ? nothing : Int(obsdim)), r) false
 
 function nystrom_sample(k::Kernel, X::AbstractVector, S::AbstractVector{<:Integer})
     Xₘ = @view X[S]
@@ -21,8 +21,11 @@ function nystrom_sample(k::Kernel, X::AbstractVector, S::AbstractVector{<:Intege
 end
 
 @deprecate nystrom_sample(
-    k::Kernel, X::AbstractMatrix, S::Vector{<:Integer}; obsdim::Union{Integer,Nothing}=defaultobs
-) nystrom_sample(k, vec_of_vecs(X; obsdim=obsdim===nothing ? nothing : Int(obsdim)), S) false
+    k::Kernel,
+    X::AbstractMatrix,
+    S::Vector{<:Integer};
+    obsdim::Union{Integer,Nothing}=defaultobs,
+) nystrom_sample(k, vec_of_vecs(X; obsdim=obsdim === nothing ? nothing : Int(obsdim)), S) false
 
 function nystrom_pinv!(Cs::Matrix{T}, tol::T=eps(T) * size(Cs, 1)) where {T<:Real}
     # Compute eigendecomposition of sampled component of K

--- a/src/matrix/kernelmatrix.jl
+++ b/src/matrix/kernelmatrix.jl
@@ -211,7 +211,9 @@ function kernelmatrix_diag!(
     )
 end
 
-function kernelmatrix_diag(κ::Kernel, X::AbstractMatrix; obsdim::Union{Int,Nothing}=defaultobs)
+function kernelmatrix_diag(
+    κ::Kernel, X::AbstractMatrix; obsdim::Union{Int,Nothing}=defaultobs
+)
     return kernelmatrix_diag(κ, vec_of_vecs(X; obsdim=obsdim))
 end
 

--- a/src/matrix/kernelmatrix.jl
+++ b/src/matrix/kernelmatrix.jl
@@ -5,18 +5,19 @@
 In-place version of [`kernelmatrix`](@ref) where pre-allocated matrix `K` will be
 overwritten with the kernel matrix.
 
-    kernelmatrix!(K::AbstractMatrix, κ::Kernel, X::AbstractMatrix; obsdim::Integer=2)
+    kernelmatrix!(K::AbstractMatrix, κ::Kernel, X::AbstractMatrix; obsdim)
     kernelmatrix!(
         K::AbstractMatrix,
         κ::Kernel,
         X::AbstractMatrix,
         Y::AbstractMatrix;
-        obsdim::Integer=2,
+        obsdim,
     )
 
-Equivalent to `kernelmatrix!(K, κ, ColVecs(X))` and
-`kernelmatrix(K, κ, ColVecs(X), ColVecs(Y))` respectively.
-Set `obsdim=1` to get `RowVecs`.
+If `obsdim=1`, equivalent to `kernelmatrix!(K, κ, RowVecs(X))` and
+`kernelmatrix(K, κ, RowVecs(X), RowVecs(Y))`, respectively.
+If `obsdim=2`, equivalent to `kernelmatrix!(K, κ, ColVecs(X))` and
+`kernelmatrix(K, κ, ColVecs(X), ColVecs(Y))`, respectively.
 
 See also: [`ColVecs`](@ref), [`RowVecs`](@ref)
 """
@@ -35,12 +36,13 @@ Compute the kernel `κ` for each pair of inputs in `x` and `y`.
 Returns a matrix of size `(length(x), length(y))` satisfying
 `kernelmatrix(κ, x, y)[p, q] == κ(x[p], y[q])`.
 
-    kernelmatrix(κ::Kernel, X::AbstractMatrix; obsdim::Int=2)
-    kernelmatrix(κ::Kernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim::Int=2)
+    kernelmatrix(κ::Kernel, X::AbstractMatrix; obsdim)
+    kernelmatrix(κ::Kernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim)
 
-Equivalent to `kernelmatrix(κ, ColVecs(X))` and `kernelmatrix(κ, ColVecs(X), ColVecs(Y))`
-respectively.
-Set `obsdim=1` to get `RowVecs`.
+If `obsdim=1`, equivalent to `kernelmatrix(κ, RowVecs(X))` and
+`kernelmatrix(κ, RowVecs(X), RowVecs(Y))`, respectively.
+If `obsdim=2`, equivalent to `kernelmatrix(κ, ColVecs(X))` and
+`kernelmatrix(κ, ColVecs(X), ColVecs(Y))`, respectively.
 
 See also: [`ColVecs`](@ref), [`RowVecs`](@ref)
 """
@@ -52,18 +54,19 @@ kernelmatrix
 
 In place version of [`kernelmatrix_diag`](@ref).
 
-    kernelmatrix_diag!(K::AbstractVector, κ::Kernel, X::AbstractMatrix; obsdim::Int=2)
+    kernelmatrix_diag!(K::AbstractVector, κ::Kernel, X::AbstractMatrix; obsdim)
     kernelmatrix_diag!(
         K::AbstractVector,
         κ::Kernel,
         X::AbstractMatrix,
         Y::AbstractMatrix;
-        obsdim::Int=2,
+        obsdim
     )
 
-Equivalent to `kernelmatrix_diag!(K, κ, ColVecs(X))` and
-`kernelmatrix_diag!(K, κ, ColVecs(X), ColVecs(Y))` respectively.
-Set `obsdim=1` to get `RowVecs`.
+If `obsdim=1`, equivalent to `kernelmatrix_diag!(K, κ, RowVecs(X))` and
+`kernelmatrix_diag!(K, κ, RowVecs(X), RowVecs(Y))`, respectively.
+If `obsdim=2`, equivalent to `kernelmatrix_diag!(K, κ, ColVecs(X))` and
+`kernelmatrix_diag!(K, κ, ColVecs(X), ColVecs(Y))`, respectively.
 
 See also: [`ColVecs`](@ref), [`RowVecs`](@ref)
 """
@@ -79,11 +82,13 @@ Compute the diagonal of `kernelmatrix(κ, x)` efficiently.
 Compute the diagonal of `kernelmatrix(κ, x, y)` efficiently.
 Requires that `x` and `y` are the same length.
 
-    kernelmatrix_diag(κ::Kernel, X::AbstractMatrix; obsdim::Int=2)
-    kernelmatrix_diag(κ::Kernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim::Int=2)
+    kernelmatrix_diag(κ::Kernel, X::AbstractMatrix; obsdim)
+    kernelmatrix_diag(κ::Kernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim)
 
-Equivalent to `kernelmatrix_diag(κ, ColVecs(X))` and
-`kernelmatrix_diag(κ, ColVecs(X), ColVecs(Y))` respectively.
+If `obsdim=1`, equivalent to `kernelmatrix_diag(κ, RowVecs(X))` and
+`kernelmatrix_diag(κ, RowVecs(X), RowVecs(Y))`, respectively.
+If `obsdim=2`, equivalent to `kernelmatrix_diag(κ, ColVecs(X))` and
+`kernelmatrix_diag(κ, ColVecs(X), ColVecs(Y))`, respectively.
 
 See also: [`ColVecs`](@ref), [`RowVecs`](@ref)
 """
@@ -162,10 +167,10 @@ end
 # Wrapper methods for AbstractMatrix inputs to maintain obsdim interface.
 #
 
-const defaultobs = 2
+const defaultobs = nothing
 
 function kernelmatrix!(
-    K::AbstractMatrix, κ::Kernel, X::AbstractMatrix; obsdim::Int=defaultobs
+    K::AbstractMatrix, κ::Kernel, X::AbstractMatrix; obsdim::Union{Int,Nothing}=defaultobs
 )
     return kernelmatrix!(K, κ, vec_of_vecs(X; obsdim=obsdim))
 end
@@ -175,12 +180,12 @@ function kernelmatrix!(
     κ::Kernel,
     X::AbstractMatrix,
     Y::AbstractMatrix;
-    obsdim::Int=defaultobs,
+    obsdim::Union{Int,Nothing}=defaultobs,
 )
     return kernelmatrix!(K, κ, vec_of_vecs(X; obsdim=obsdim), vec_of_vecs(Y; obsdim=obsdim))
 end
 
-function kernelmatrix(κ::Kernel, X::AbstractMatrix; obsdim::Int=defaultobs)
+function kernelmatrix(κ::Kernel, X::AbstractMatrix; obsdim::Union{Int,Nothing}=defaultobs)
     return kernelmatrix(κ, vec_of_vecs(X; obsdim=obsdim))
 end
 
@@ -189,7 +194,7 @@ function kernelmatrix(κ::Kernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim=d
 end
 
 function kernelmatrix_diag!(
-    K::AbstractVector, κ::Kernel, X::AbstractMatrix; obsdim::Int=defaultobs
+    K::AbstractVector, κ::Kernel, X::AbstractMatrix; obsdim::Union{Int,Nothing}=defaultobs
 )
     return kernelmatrix_diag!(K, κ, vec_of_vecs(X; obsdim=obsdim))
 end
@@ -199,19 +204,19 @@ function kernelmatrix_diag!(
     κ::Kernel,
     X::AbstractMatrix,
     Y::AbstractMatrix;
-    obsdim::Int=defaultobs,
+    obsdim::Union{Int,Nothing}=defaultobs,
 )
     return kernelmatrix_diag!(
         K, κ, vec_of_vecs(X; obsdim=obsdim), vec_of_vecs(Y; obsdim=obsdim)
     )
 end
 
-function kernelmatrix_diag(κ::Kernel, X::AbstractMatrix; obsdim::Int=defaultobs)
+function kernelmatrix_diag(κ::Kernel, X::AbstractMatrix; obsdim::Union{Int,Nothing}=defaultobs)
     return kernelmatrix_diag(κ, vec_of_vecs(X; obsdim=obsdim))
 end
 
 function kernelmatrix_diag(
-    κ::Kernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim::Int=defaultobs
+    κ::Kernel, X::AbstractMatrix, Y::AbstractMatrix; obsdim::Union{Int,Nothing}=defaultobs
 )
     return kernelmatrix_diag(
         κ, vec_of_vecs(X; obsdim=obsdim), vec_of_vecs(Y; obsdim=obsdim)

--- a/src/matrix/kernelpdmat.jl
+++ b/src/matrix/kernelpdmat.jl
@@ -3,7 +3,6 @@ using .PDMats: PDMat
 export kernelpdmat
 
 """
-    kernelpdmat(k::Kernel, X::AbstractMatrix; obsdim)
     kernelpdmat(k::Kernel, X::AbstractVector)
 
 Compute a positive-definite matrix in the form of a `PDMat` matrix (see [PDMats.jl](https://github.com/JuliaStats/PDMats.jl)),
@@ -11,10 +10,6 @@ with the Cholesky decomposition precomputed.
 The algorithm adds a diagonal "nugget" term to the kernel matrix which is increased until positive
 definiteness is achieved. The algorithm gives up with an error if the nugget becomes larger than 1% of the largest value in the kernel matrix.
 """
-function kernelpdmat(κ::Kernel, X::AbstractMatrix; obsdim::Union{Int,Nothing}=defaultobs)
-    return kernelpdmat(κ, vec_of_vecs(X; obsdim=obsdim))
-end
-
 function kernelpdmat(κ::Kernel, X::AbstractVector)
     K = kernelmatrix(κ, X)
     Kmax = maximum(K)
@@ -30,4 +25,16 @@ function kernelpdmat(κ::Kernel, X::AbstractVector)
         )
     end
     return PDMat(K + α * I)
+end
+
+"""
+    kernelpdmat(k::Kernel, X::AbstractMatrix; obsdim)
+
+If `obsdim=1`, equivalent to `kernelpdmat(k, RowVecs(X))`.
+If `obsdim=2`, equivalent to `kernelpdmat(k, ColVecs(X))`.
+
+See also: [`ColVecs`](@ref), [`RowVecs`](@ref)
+"""
+function kernelpdmat(κ::Kernel, X::AbstractMatrix; obsdim::Union{Int,Nothing}=defaultobs)
+    return kernelpdmat(κ, vec_of_vecs(X; obsdim=obsdim))
 end

--- a/src/matrix/kernelpdmat.jl
+++ b/src/matrix/kernelpdmat.jl
@@ -3,7 +3,7 @@ using .PDMats: PDMat
 export kernelpdmat
 
 """
-    kernelpdmat(k::Kernel, X::AbstractMatrix; obsdim::Int=2)
+    kernelpdmat(k::Kernel, X::AbstractMatrix; obsdim)
     kernelpdmat(k::Kernel, X::AbstractVector)
 
 Compute a positive-definite matrix in the form of a `PDMat` matrix (see [PDMats.jl](https://github.com/JuliaStats/PDMats.jl)),
@@ -11,7 +11,7 @@ with the Cholesky decomposition precomputed.
 The algorithm adds a diagonal "nugget" term to the kernel matrix which is increased until positive
 definiteness is achieved. The algorithm gives up with an error if the nugget becomes larger than 1% of the largest value in the kernel matrix.
 """
-function kernelpdmat(κ::Kernel, X::AbstractMatrix; obsdim::Int=defaultobs)
+function kernelpdmat(κ::Kernel, X::AbstractMatrix; obsdim::Union{Int,Nothing}=defaultobs)
     return kernelpdmat(κ, vec_of_vecs(X; obsdim=obsdim))
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,26 +21,27 @@ macro check_args(K, param, cond, desc=string(cond))
     end
 end
 
-function deprecated_obsdim(obsdim::Union{Nothing,Integer})
-    if obsdim === nothing
+function deprecated_obsdim(obsdim::Union{Int,Nothing})
+    return if obsdim === nothing
         Base.depwarn(
             "implicit `obsdim=2` argument is deprecated and now has to be passed " *
             "explicitly to specify that each column corresponds to one observation",
             :vec_of_vecs,
         )
-        return 2
+        2
     else
-        return obsdim
+        obsdim
     end
 end
 
-function vec_of_vecs(X::AbstractMatrix; obsdim::Union{Nothing,Int}=nothing)
+function vec_of_vecs(X::AbstractMatrix; obsdim::Union{Int,Nothing}=nothing)
     _obsdim = deprecated_obsdim(obsdim)
-    @assert _obsdim ∈ (1, 2) "obsdim should be 1 or 2, see docs of kernelmatrix"
-    if _obsdim == 1
+    return if _obsdim == 1
         RowVecs(X)
-    else
+    elseif _obsdim == 2
         ColVecs(X)
+    else
+        throw(ArgumentError("`obsdim` keyword argument should be 1 or 2"))
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,10 +38,10 @@ end
 
 function vec_of_vecs(X::AbstractMatrix; obsdim::Union{Int,Nothing}=nothing)
     _obsdim = deprecated_obsdim(obsdim)
-    return if _obsdim == 1
-        RowVecs(X)
+    if _obsdim == 1
+        return RowVecs(X)
     elseif _obsdim == 2
-        ColVecs(X)
+        return ColVecs(X)
     else
         throw(ArgumentError("`obsdim` keyword argument should be 1 or 2"))
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,9 +21,21 @@ macro check_args(K, param, cond, desc=string(cond))
     end
 end
 
-function vec_of_vecs(X::AbstractMatrix; obsdim::Int=2)
-    @assert obsdim ∈ (1, 2) "obsdim should be 1 or 2, see docs of kernelmatrix"
-    if obsdim == 1
+function deprecated_obsdim(obsdim::Union{Nothing,Integer})
+    if obsdim === nothing
+        Base.depwarn("implicit `obsdim=2` argument now has to be passed explicitly " *
+                     "to specify that columns are observation",
+                     :vec_of_vecs)
+        return 2
+    else
+        return obsdim
+    end
+end
+
+function vec_of_vecs(X::AbstractMatrix; obsdim::Union{Nothing,Int}=nothing)
+    _obsdim = deprecated_obsdim(obsdim)
+    @assert _obsdim ∈ (1, 2) "obsdim should be 1 or 2, see docs of kernelmatrix"
+    if _obsdim == 1
         RowVecs(X)
     else
         ColVecs(X)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,7 +33,6 @@ function deprecated_obsdim(obsdim::Union{Int,Nothing})
         obsdim
     end
     return _obsdim
-    end
 end
 
 function vec_of_vecs(X::AbstractMatrix; obsdim::Union{Int,Nothing}=nothing)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,7 +25,7 @@ function deprecated_obsdim(obsdim::Union{Nothing,Integer})
     if obsdim === nothing
         Base.depwarn(
             "implicit `obsdim=2` argument is deprecated and now has to be passed " *
-            "explicitly to specify that columns are observation",
+            "explicitly to specify that each column corresponds to one observation",
             :vec_of_vecs,
         )
         return 2

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -23,9 +23,11 @@ end
 
 function deprecated_obsdim(obsdim::Union{Nothing,Integer})
     if obsdim === nothing
-        Base.depwarn("implicit `obsdim=2` argument now has to be passed explicitly " *
-                     "to specify that columns are observation",
-                     :vec_of_vecs)
+        Base.depwarn(
+            "implicit `obsdim=2` argument now has to be passed explicitly " *
+            "to specify that columns are observation",
+            :vec_of_vecs,
+        )
         return 2
     else
         return obsdim

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,8 +24,8 @@ end
 function deprecated_obsdim(obsdim::Union{Nothing,Integer})
     if obsdim === nothing
         Base.depwarn(
-            "implicit `obsdim=2` argument now has to be passed explicitly " *
-            "to specify that columns are observation",
+            "implicit `obsdim=2` argument is deprecated and now has to be passed " *
+            "explicitly to specify that columns are observation",
             :vec_of_vecs,
         )
         return 2

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -22,7 +22,7 @@ macro check_args(K, param, cond, desc=string(cond))
 end
 
 function deprecated_obsdim(obsdim::Union{Int,Nothing})
-    return if obsdim === nothing
+    _obsdim = if obsdim === nothing
         Base.depwarn(
             "implicit `obsdim=2` argument is deprecated and now has to be passed " *
             "explicitly to specify that each column corresponds to one observation",
@@ -31,6 +31,8 @@ function deprecated_obsdim(obsdim::Union{Int,Nothing})
         2
     else
         obsdim
+    end
+    return _obsdim
     end
 end
 

--- a/test/approximations/nystrom.jl
+++ b/test/approximations/nystrom.jl
@@ -8,7 +8,8 @@
         @test kernelmatrix(k, X; obsdim=obsdim) ≈
             kernelmatrix(nystrom(k, X, collect(1:dims[obsdim]); obsdim=obsdim))
     end
-    r = rand()
-    @test @test_deprecated(nystrom(k, X, r)) ≈ nystrom(k, ColVecs(X), r)
-    @test @test_deprecated(nystrom(k, X, 2:4)) ≈ nystrom(k, ColVecs(X), 2:4)
+    @test kernelmatrix(@test_deprecated(nystrom(k, X, 1.0))) ≈
+        kernelmatrix(nystrom(k, ColVecs(X), 1.0))
+    @test kernelmatrix(@test_deprecated(nystrom(k, X, 1:5))) ≈
+        kernelmatrix(nystrom(k, ColVecs(X), 1:5))
 end

--- a/test/approximations/nystrom.jl
+++ b/test/approximations/nystrom.jl
@@ -8,4 +8,7 @@
         @test kernelmatrix(k, X; obsdim=obsdim) ≈
               kernelmatrix(nystrom(k, X, collect(1:dims[obsdim]); obsdim=obsdim))
     end
+    r = rand()
+    @test @test_deprecated(nystrom(k, X, r)) ≈ nystrom(k, ColVecs(X), r)
+    @test @test_deprecated(nystrom(k, X, 2:4)) ≈ nystrom(k, ColVecs(X), 2:4)
 end

--- a/test/approximations/nystrom.jl
+++ b/test/approximations/nystrom.jl
@@ -4,9 +4,9 @@
     k = SqExponentialKernel()
     for obsdim in [1, 2]
         @test kernelmatrix(k, X; obsdim=obsdim) ≈
-              kernelmatrix(nystrom(k, X, 1.0; obsdim=obsdim))
+            kernelmatrix(nystrom(k, X, 1.0; obsdim=obsdim))
         @test kernelmatrix(k, X; obsdim=obsdim) ≈
-              kernelmatrix(nystrom(k, X, collect(1:dims[obsdim]); obsdim=obsdim))
+            kernelmatrix(nystrom(k, X, collect(1:dims[obsdim]); obsdim=obsdim))
     end
     r = rand()
     @test @test_deprecated(nystrom(k, X, r)) ≈ nystrom(k, ColVecs(X), r)

--- a/test/basekernels/fbm.jl
+++ b/test/basekernels/fbm.jl
@@ -5,7 +5,7 @@
     v1 = rand(rng, 3)
     v2 = rand(rng, 3)
     @test k(v1, v2) ≈
-          (
+        (
         sqeuclidean(v1, zero(v1))^h + sqeuclidean(v2, zero(v2))^h -
         sqeuclidean(v1 - v2, zero(v1 - v2))^h
     ) / 2 atol = 1e-5

--- a/test/basekernels/matern.jl
+++ b/test/basekernels/matern.jl
@@ -45,7 +45,7 @@
         k = Matern52Kernel()
         @test kappa(k, x) ≈ (1 + sqrt(5) * x + 5 / 3 * x^2)exp(-sqrt(5) * x)
         @test k(v1, v2) ≈
-              (
+            (
             1 + sqrt(5) * norm(v1 - v2) + 5 / 3 * norm(v1 - v2)^2
         )exp(-sqrt(5) * norm(v1 - v2))
         @test kappa(Matern52Kernel(), x) == kappa(k, x)

--- a/test/basekernels/piecewisepolynomial.jl
+++ b/test/basekernels/piecewisepolynomial.jl
@@ -20,7 +20,7 @@
     @test PiecewisePolynomialKernel(; dim=D) isa PiecewisePolynomialKernel{0}
 
     @test repr(k) ==
-          "Piecewise Polynomial Kernel (degree = $(degree), ⌊dim/2⌋ = $(div(D, 2)), metric = Euclidean(0.0))"
+        "Piecewise Polynomial Kernel (degree = $(degree), ⌊dim/2⌋ = $(div(D, 2)), metric = Euclidean(0.0))"
 
     k3 = PiecewisePolynomialKernel(;
         degree=degree, dim=D, metric=WeightedEuclidean(ones(D))

--- a/test/basekernels/wiener.jl
+++ b/test/basekernels/wiener.jl
@@ -27,9 +27,9 @@
     @test k0(v1, v2) ≈ minXY
     @test k1(v1, v2) ≈ 1 / 3 * minXY^3 + 1 / 2 * minXY^2 * euclidean(v1, v2)
     @test k2(v1, v2) ≈
-          1 / 20 * minXY^5 + 1 / 12 * minXY^3 * euclidean(v1, v2) * (X + Y - 1 / 2 * minXY)
+        1 / 20 * minXY^5 + 1 / 12 * minXY^3 * euclidean(v1, v2) * (X + Y - 1 / 2 * minXY)
     @test k3(v1, v2) ≈
-          1 / 252 * minXY^7 +
+        1 / 252 * minXY^7 +
           1 / 720 *
           minXY^4 *
           euclidean(v1, v2) *

--- a/test/kernels/gibbskernel.jl
+++ b/test/kernels/gibbskernel.jl
@@ -8,6 +8,6 @@
     k_gibbs = GibbsKernel(ell)
 
     @test k_gibbs(x, y) ≈
-          sqrt((2 * ell(x) * ell(y)) / (ell(x)^2 + ell(y)^2)) *
+        sqrt((2 * ell(x) * ell(y)) / (ell(x)^2 + ell(y)^2)) *
           exp(-(x - y)^2 / (ell(x)^2 + ell(y)^2))
 end

--- a/test/kernels/neuralkernelnetwork.jl
+++ b/test/kernels/neuralkernelnetwork.jl
@@ -43,12 +43,12 @@ using KernelFunctions: NeuralKernelNetwork, LinearLayer, product, Primitive
             # Vector input.
             @test kernelmatrix_diag(nkn_add_kernel, x0) ≈ kernelmatrix_diag(sum_k, x0)
             @test kernelmatrix_diag(nkn_add_kernel, x0, x1) ≈
-                  kernelmatrix_diag(sum_k, x0, x1)
+                kernelmatrix_diag(sum_k, x0, x1)
 
             # ColVecs input.
             @test kernelmatrix_diag(nkn_add_kernel, X0) ≈ kernelmatrix_diag(sum_k, X0)
             @test kernelmatrix_diag(nkn_add_kernel, X0, X1) ≈
-                  kernelmatrix_diag(sum_k, X0, X1)
+                kernelmatrix_diag(sum_k, X0, X1)
         end
         @testset "product" begin
             nkn_prod_kernel = NeuralKernelNetwork(primitives, product)

--- a/test/kernels/transformedkernel.jl
+++ b/test/kernels/transformedkernel.jl
@@ -19,8 +19,8 @@
     @test ktard(v1, v2) == (k ∘ ARDTransform(v))(v1, v2)
     @test ktard(v1, v2) == k(v .* v1, v .* v2)
     @test (k ∘ LinearTransform(P') ∘ ScaleTransform(s))(v1, v2) ==
-          ((k ∘ LinearTransform(P')) ∘ ScaleTransform(s))(v1, v2) ==
-          (k ∘ (LinearTransform(P') ∘ ScaleTransform(s)))(v1, v2)
+        ((k ∘ LinearTransform(P')) ∘ ScaleTransform(s))(v1, v2) ==
+        (k ∘ (LinearTransform(P') ∘ ScaleTransform(s)))(v1, v2)
 
     @test repr(kt) == repr(k) * "\n\t- " * repr(ScaleTransform(s))
 

--- a/test/matrix/kernelmatrix.jl
+++ b/test/matrix/kernelmatrix.jl
@@ -139,6 +139,36 @@ KernelFunctions.kappa(::ToySimpleKernel, d) = exp(-d / 2)
                   kernelmatrix_diag(k, x, x)
             @test tmp_diag ≈ kernelmatrix_diag(k, x, x)
         end
+
+        @testset "deprecated default" begin
+            X = randn(rng, D, Nx)
+            Y = randn(rng, D, Ny)
+            x = ColVecs(X)
+            y = ColVecs(Y)
+
+            @test kernelmatrix(k, x, y) == @test_deprecated(kernelmatrix(k, X, Y))
+
+            @test kernelmatrix(k, x) ≈ @test_deprecated(kernelmatrix(k, X))
+
+            @test kernelmatrix_diag(k, x) ≈ @test_deprecaetd(kernelmatrix_diag(k, X))
+
+            tmp = Matrix{Float64}(undef, length(x), length(y))
+            @test kernelmatrix(k, x, y) ≈ @test_deprecated(kernelmatrix!(tmp, k, X, Y))
+            @test kernelmatrix(k, x, y) ≈ tmp
+
+            tmp_square = Matrix{Float64}(undef, length(x), length(x))
+            @test kernelmatrix(k, x) ≈ @test_deprecated(kernelmatrix!(tmp_square, k, X))
+            @test kernelmatrix(k, x) ≈ tmp_square
+
+            tmp_diag = Vector{Float64}(undef, length(x))
+            @test kernelmatrix_diag(k, x) ≈
+                  @test_deprecated(kernelmatrix_diag!(tmp_diag, k, X))
+            @test kernelmatrix_diag(k, x) ≈ tmp_diag
+            tmp_diag = Vector{Float64}(undef, length(x))
+            @test @test_deprecated(kernelmatrix_diag!(tmp_diag, k, X, X)) ≈
+                  kernelmatrix_diag(k, x, x)
+            @test tmp_diag ≈ kernelmatrix_diag(k, x, x)
+        end
     end
 
     @testset "Multi Output Kernels" begin

--- a/test/matrix/kernelmatrix.jl
+++ b/test/matrix/kernelmatrix.jl
@@ -132,11 +132,11 @@ KernelFunctions.kappa(::ToySimpleKernel, d) = exp(-d / 2)
 
             tmp_diag = Vector{Float64}(undef, length(x))
             @test kernelmatrix_diag(k, x) ≈
-                  kernelmatrix_diag!(tmp_diag, k, X; obsdim=obsdim)
+                kernelmatrix_diag!(tmp_diag, k, X; obsdim=obsdim)
             @test kernelmatrix_diag(k, x) ≈ tmp_diag
             tmp_diag = Vector{Float64}(undef, length(x))
             @test kernelmatrix_diag!(tmp_diag, k, X, X; obsdim=obsdim) ≈
-                  kernelmatrix_diag(k, x, x)
+                kernelmatrix_diag(k, x, x)
             @test tmp_diag ≈ kernelmatrix_diag(k, x, x)
         end
 
@@ -162,11 +162,11 @@ KernelFunctions.kappa(::ToySimpleKernel, d) = exp(-d / 2)
 
             tmp_diag = Vector{Float64}(undef, length(x))
             @test kernelmatrix_diag(k, x) ≈
-                  @test_deprecated(kernelmatrix_diag!(tmp_diag, k, X))
+                @test_deprecated(kernelmatrix_diag!(tmp_diag, k, X))
             @test kernelmatrix_diag(k, x) ≈ tmp_diag
             tmp_diag = Vector{Float64}(undef, length(x))
             @test @test_deprecated(kernelmatrix_diag!(tmp_diag, k, X, X)) ≈
-                  kernelmatrix_diag(k, x, x)
+                kernelmatrix_diag(k, x, x)
             @test tmp_diag ≈ kernelmatrix_diag(k, x, x)
         end
     end

--- a/test/matrix/kernelmatrix.jl
+++ b/test/matrix/kernelmatrix.jl
@@ -150,7 +150,7 @@ KernelFunctions.kappa(::ToySimpleKernel, d) = exp(-d / 2)
 
             @test kernelmatrix(k, x) ≈ @test_deprecated(kernelmatrix(k, X))
 
-            @test kernelmatrix_diag(k, x) ≈ @test_deprecaetd(kernelmatrix_diag(k, X))
+            @test kernelmatrix_diag(k, x) ≈ @test_deprecated(kernelmatrix_diag(k, X))
 
             tmp = Matrix{Float64}(undef, length(x), length(y))
             @test kernelmatrix(k, x, y) ≈ @test_deprecated(kernelmatrix!(tmp, k, X, Y))

--- a/test/matrix/kernelpdmat.jl
+++ b/test/matrix/kernelpdmat.jl
@@ -12,4 +12,5 @@
         @test kernelpdmat(k, vecA[obsdim]) == kernelpdmat(k, A; obsdim=obsdim)
         # @test_throws ErrorException kernelpdmat(k,ones(100,100),obsdim=obsdim)
     end
+    @test @test_deprecated(kernelpdmat(k, A)) == kernelpdmat(k, ColVecs(A))
 end

--- a/test/mokernels/independent.jl
+++ b/test/mokernels/independent.jl
@@ -27,6 +27,6 @@
     @test eltype(typeof(kernelmatrix(k, x2))) <: Float32
 
     @test string(k) ==
-          "Independent Multi-Output Kernel\n" *
+        "Independent Multi-Output Kernel\n" *
           "\tSquared Exponential Kernel (metric = Euclidean(0.0))"
 end

--- a/test/mokernels/intrinsiccoregion.jl
+++ b/test/mokernels/intrinsiccoregion.jl
@@ -27,9 +27,9 @@
     @test icoregionkernel.B == B
     @test icoregionkernel.kernel == kernel
     @test icoregionkernel(XIF[1], XIF[1]) ≈
-          B[XIF[1][2], XIF[1][2]] * kernel(XIF[1][1], XIF[1][1])
+        B[XIF[1][2], XIF[1][2]] * kernel(XIF[1][1], XIF[1][1])
     @test icoregionkernel(XIF[1], XIF[end]) ≈
-          B[XIF[1][2], XIF[end][2]] * kernel(XIF[1][1], XIF[end][1])
+        B[XIF[1][2], XIF[end][2]] * kernel(XIF[1][1], XIF[end][1])
 
     # kernelmatrix
     KernelFunctions.TestUtils.test_interface(icoregionkernel, XIF, YIF, ZIF)
@@ -43,5 +43,5 @@
     test_ADs(icoregionkernel; dims=dims)
 
     @test string(icoregionkernel) ==
-          string("Intrinsic Coregion Kernel: ", kernel, " with ", dims.out, " outputs")
+        string("Intrinsic Coregion Kernel: ", kernel, " with ", dims.out, " outputs")
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -7,8 +7,10 @@
     w = randn(rng, N)
 
     @testset "VecOfVecs" begin
-        @test vec_of_vecs(X; obsdim=2) == ColVecs(X)
         @test vec_of_vecs(X; obsdim=1) == RowVecs(X)
+        @test vec_of_vecs(X; obsdim=2) == ColVecs(X)
+        @test_throws ArgumentError vec_of_vecs(X; obsdim=0)
+        @test_throws ArgumentError vec_of_vecs(X; obsdim=3)
     end
     # Test Matrix data sets.
     @testset "ColVecs" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -30,9 +30,9 @@
         Y = randn(rng, D, N + 1)
         DY = ColVecs(Y)
         @test KernelFunctions.pairwise(SqEuclidean(), DX) ≈
-              pairwise(SqEuclidean(), X; dims=2)
+            pairwise(SqEuclidean(), X; dims=2)
         @test KernelFunctions.pairwise(SqEuclidean(), DX, DY) ≈
-              pairwise(SqEuclidean(), X, Y; dims=2)
+            pairwise(SqEuclidean(), X, Y; dims=2)
         @test vcat(DX, DY) isa ColVecs
         @test vcat(DX, DY).X == hcat(X, Y)
         K = zeros(N, N)
@@ -87,9 +87,9 @@
         Y = randn(rng, D + 1, N)
         DY = RowVecs(Y)
         @test KernelFunctions.pairwise(SqEuclidean(), DX) ≈
-              pairwise(SqEuclidean(), X; dims=1)
+            pairwise(SqEuclidean(), X; dims=1)
         @test KernelFunctions.pairwise(SqEuclidean(), DX, DY) ≈
-              pairwise(SqEuclidean(), X, Y; dims=1)
+            pairwise(SqEuclidean(), X, Y; dims=1)
         @test vcat(DX, DY) isa RowVecs
         @test vcat(DX, DY).X == vcat(X, Y)
         K = zeros(D, D)


### PR DESCRIPTION
Lately, due to the discussions also in AbstractGPs, I thought a bit about our support of matrices and the `obsdim` keyword argument.

I realized that I like it that one can still call `kernelmatrix` etc. with matrices, even though internally we only work with `RowVecs` and `ColVecs` (fortunately :pray:). I think this might make it a bit easier for new users as they don't have to learn about `ColVecs` and `RowVecs` right away - and even to me sometimes it feels quite nice, e.g., if other parts and packages of my script don't work with, or don't even know about, `ColVecs`/`RowVecs` and the hence the most natural form of the data is a raw matrix with a clearly defined convention (rows or columns).

However, I also realized that I really don't like it that there is an implicit default `obsdim` since this makes code more difficult to read and reason about and could lead to misunderstandings and bugs. And any default choice is somewhat arbitrary and probably heavily biased by research area and personal preferences.

I think one can get both - matrices as arguments and no default convention - by deprecating the default implicit `obsdim` keyword argument and requiring users to state `obsdim` explicitly. A prominent example of another package that did this is Distances.jl.

The idea grew on me, and hence I put together this PR. It has to be updated once #427 is merged.