### PR TITLE
ConstantKernel Performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.29"
+version = "0.10.30"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/basekernels/constant.jl
+++ b/src/basekernels/constant.jl
@@ -78,12 +78,11 @@ kappa(κ::ConstantKernel, x::Real) = only(κ.c) * one(x)
 metric(::ConstantKernel) = Delta()
 
 function kernelmatrix(k::ConstantKernel, x::AbstractVector)
-    return Fill(only(k.c), length(x), length(x))
+    return fill(only(k.c), length(x), length(x))
 end
 
 function kernelmatrix(k::ConstantKernel, x::AbstractVector, y::AbstractVector)
-    return Fill(only(k.c), length(x), length(y))
+    return fill(only(k.c), length(x), length(y))
 end
-
 
 Base.show(io::IO, κ::ConstantKernel) = print(io, "Constant Kernel (c = ", only(κ.c), ")")

--- a/src/basekernels/constant.jl
+++ b/src/basekernels/constant.jl
@@ -78,11 +78,11 @@ kappa(κ::ConstantKernel, x::Real) = only(κ.c) * one(x)
 metric(::ConstantKernel) = Delta()
 
 function kernelmatrix(k::ConstantKernel, x::AbstractVector)
-    return fill(only(k.c), length(x), length(x))
+    return Fill(only(k.c), length(x), length(x))
 end
 
 function kernelmatrix(k::ConstantKernel, x::AbstractVector, y::AbstractVector)
-    return fill(only(k.c), length(x), length(y))
+    return Fill(only(k.c), length(x), length(y))
 end
 
 

--- a/src/basekernels/constant.jl
+++ b/src/basekernels/constant.jl
@@ -77,4 +77,13 @@ kappa(κ::ConstantKernel, x::Real) = only(κ.c) * one(x)
 
 metric(::ConstantKernel) = Delta()
 
+function kernelmatrix(k::ConstantKernel, x::AbstractVector)
+    return fill(only(k.c), length(x), length(x))
+end
+
+function kernelmatrix(k::ConstantKernel, x::AbstractVector, y::AbstractVector)
+    return fill(only(k.c), length(x), length(y))
+end
+
+
 Base.show(io::IO, κ::ConstantKernel) = print(io, "Constant Kernel (c = ", only(κ.c), ")")


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
<!-- Summary of what & why - explain your motivation and/or link to any GitHub issues this relates to -->

I found a lovely pathological Zygote-related performance problem.

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
Optimisations for `kernelmatrix` for the ConstantKernel

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

The only other option is to improve Zygote's handling of `map`. Unfortunately I can't see Zygote improving here in the immediate future (I certainly don't have time to look into it right now).

**Breaking changes**
<!-- If this PR breaks backwards-compatibility, please start the PR title with `**BREAKING**`! -->
<!-- In this section, describe any changes that are not backwards-compatible, -->
<!-- why it is worth breaking backwards compatiblity, -->
<!-- and how a user would have to address these changes in their downstream code. -->
None

**Performance**

Here's a demo of how awful the performance is at the minute vs this PR:
```julia
using BenchmarkTools
using KernelFunctions
using Zygote

function foo(c, x, y)
    return kernelmatrix(ConstantKernel(c=c), x, y)
end

c = 1.0
x = randn(1_000)
y = randn(1_500)

@benchmark foo($c, $x, $y)
@benchmark Zygote.pullback(foo, $c, $x, $y)

out, pb = Zygote.pullback(foo, c, x, y)
@benchmark $pb($out)

# Without PR

# Primal:
BenchmarkTools.Trial: 956 samples with 1 evaluation.
 Range (min … max):  4.362 ms …   7.830 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.087 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.222 ms ± 515.433 μs  ┊ GC (mean ± σ):  6.09% ± 9.28%

       ▂           █▆▆▁▁
  ▂▂▃▄▆██▅▅▅▃▃▃▃▄▄▄█████▅▅▄▄▄▄▃▁▂▂▂▃▃▃▄▅▇▇▆▆▅▄▄▃▃▃▃▂▂▃▃▂▁▂▁▂▂ ▃
  4.36 ms         Histogram: frequency by time        6.56 ms <

 Memory estimate: 12.89 MiB, allocs estimate: 14.

# Forwards-pass:
BenchmarkTools.Trial: 1 sample with 1 evaluation.
 Single result which took 12.314 s (51.96% GC) to evaluate,
 with a memory estimate of 4.51 GiB, over 97500049 allocations.

# Reverse-pass:
BenchmarkTools.Trial: 1 sample with 1 evaluation.
 Single result which took 27.904 s (11.51% GC) to evaluate,
 with a memory estimate of 2.50 GiB, over 96000081 allocations.


# With PR:

# Primal
BenchmarkTools.Trial: 1449 samples with 1 evaluation.
 Range (min … max):  1.396 ms … 11.263 ms  ┊ GC (min … max):  0.00% … 67.42%
 Time  (median):     2.212 ms              ┊ GC (median):     0.00%
 Time  (mean ± σ):   3.437 ms ±  2.456 ms  ┊ GC (mean ± σ):  43.52% ± 33.98%

       ▅█
  ██▅▃▃███▄▃▂▂▂▂▂▁▁▁▂▁▂▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▄▆▅▅▃▃▃▂▂▂▂▂ ▃
  1.4 ms         Histogram: frequency by time        8.73 ms <

 Memory estimate: 11.44 MiB, allocs estimate: 6.

# Forwards-pass
BenchmarkTools.Trial: 1285 samples with 1 evaluation.
 Range (min … max):  1.732 ms … 10.228 ms  ┊ GC (min … max):  0.00% … 79.74%
 Time  (median):     2.147 ms              ┊ GC (median):     0.00%
 Time  (mean ± σ):   3.880 ms ±  3.025 ms  ┊ GC (mean ± σ):  44.58% ± 32.92%

    █▆▃▁                                            ▂▃▃▂▁▁
  ▇█████▅▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▁▁▄▄▆███████▇ █
  1.73 ms      Histogram: log(frequency) by time     9.79 ms <

 Memory estimate: 11.45 MiB, allocs estimate: 98.

# Reverse-pass
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  23.841 μs … 164.260 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     24.554 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   26.567 μs ±   7.206 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▆█▆▃▂▂▂▃▂▂ ▂▁▁ ▁ ▁▂ ▁▁▃▄▂▁                                   ▂
  ██████████████████████████▇▇▆▅▅▅▄▅▅▅▅▅▄▄▄▁▄▅▃▁▄▄▄▁▄▅▃▁▃▄▄▅▃▅ █
  23.8 μs       Histogram: log(frequency) by time      48.6 μs <

 Memory estimate: 2.61 KiB, allocs estimate: 107.
```

You get similar results for the two-argument method of `kernelmatrix`.
