### PR TITLE
Add more kernels to the benchmark and AD benchmarks

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,3 +1,11 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KernelFunctions = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[compat]
+BenchmarkTools = "1"
+ForwardDiff = "0.10"
+Zygote = "0.6"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -65,9 +65,15 @@ for (kname, (kargs, kf)) in kernels
     for (inputname, (X, Y)) in inputtypes
         suite_kernel[inputname] = suite_input = BenchmarkGroup()
         for (fname, f) in functions
-            suite_input[fname] = @benchmarkable Zygote.pullback($kargs, $X, $Y) do args, x, y
+            # Forward-pass
+            suite_input[fname * "_forward"] = @benchmarkable Zygote.pullback($kargs, $X, $Y) do args, x, y
                 $f($kf, args, x, y)
             end
+            # Reverse pass
+            out, pb = Zygote.pullback(kargs, X, Y) do args, x, y
+                f(kf, args, x, y)
+            end
+            suite_input[fname * "_reverse"] = @benchmarkable $pb($out)
         end
     end
 end


### PR DESCRIPTION
Adds a pair more kernels and benchmarks for AD
Right now the issue is with ForwardDiff where I am not sure how to turn the parameters into a single `Array`, if we want to use `ParameterHandling` we first need https://github.com/invenia/ParameterHandling.jl/pull/39 to be merged.
