### PR TITLE
Add optimized implementations for `ZeroKernel` and `ConstantKernel`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.32"
+version = "0.10.33"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/basekernels/constant.jl
+++ b/src/basekernels/constant.jl
@@ -15,9 +15,40 @@ See also: [`ConstantKernel`](@ref)
 """
 struct ZeroKernel <: SimpleKernel end
 
-kappa(κ::ZeroKernel, d::T) where {T<:Real} = zero(T)
-
+# SimpleKernel interface
+kappa(::ZeroKernel, ::Real) = false
 metric(::ZeroKernel) = Delta()
+
+# Optimizations
+(::ZeroKernel)(x, y) = false
+kernelmatrix(::ZeroKernel, x::AbstractVector) = Falses(length(x), length(x))
+function kernelmatrix(::ZeroKernel, x::AbstractVector, y::AbstractVector)
+    validate_inputs(x, y)
+    return Falses(length(x), length(y))
+end
+function kernelmatrix!(K::AbstractMatrix, ::ZeroKernel, x::AbstractVector)
+    validate_inplace_dims(K, x)
+    return fill!(K, zero(eltype(K)))
+end
+function kernelmatrix!(K::AbstractMatrix, ::ZeroKernel, x::AbstractVector, y::AbstractVector)
+    validate_inplace_dims(K, x, y)
+    return fill!(K, zero(eltype(K)))
+end
+kernelmatrix_diag(::ZeroKernel, x::AbstractVector) = Falses(length(x))
+function kernelmatrix_diag(::ZeroKernel, x::AbstractVector, y::AbstractVector)
+    validate_inputs(x, y)
+    return Falses(length(x))
+end
+function kernelmatrix_diag!(K::AbstractVector, ::ZeroKernel, x::AbstractVector)
+    validate_inplace_dims(K, x)
+    return fill!(K, zero(eltype(K)))
+end
+function kernelmatrix_diag!(
+    K::AbstractVector, ::ZeroKernel, x::AbstractVector, y::AbstractVector
+)
+    validate_inplace_dims(K, x, y)
+    return fill!(K, zero(eltype(K)))
+end
 
 Base.show(io::IO, ::ZeroKernel) = print(io, "Zero Kernel")
 
@@ -73,14 +104,39 @@ end
 
 @functor ConstantKernel
 
-kappa(κ::ConstantKernel, x::Real) = only(κ.c) * one(x)
-
+# SimpleKernel interface
+kappa(κ::ConstantKernel, ::Real) = only(κ.c)
 metric(::ConstantKernel) = Delta()
 
+# Optimizations
+(k::ConstantKernel)(x, y) = only(k.c)
 kernelmatrix(k::ConstantKernel, x::AbstractVector) = Fill(only(k.c), length(x), length(x))
-
 function kernelmatrix(k::ConstantKernel, x::AbstractVector, y::AbstractVector)
+    validate_inputs(x, y)
     return Fill(only(k.c), length(x), length(y))
+end
+function kernelmatrix!(K::AbstractMatrix, k::ConstantKernel, x::AbstractVector)
+    validate_inplace_dims(K, x)
+    return fill!(K, only(k.c))
+end
+function kernelmatrix!(K::AbstractMatrix, k::ConstantKernel, x::AbstractVector, y::AbstractVector)
+    validate_inplace_dims(K, x, y)
+    return fill!(K, only(k.c))
+end
+kernelmatrix_diag(k::ConstantKernel, x::AbstractVector) = Fill(only(k.c), length(x))
+function kernelmatrix_diag(k::ConstantKernel, x::AbstractVector, y::AbstractVector)
+    validate_inputs(x, y)
+    return Fill(only(k.c), length(x))
+end
+function kernelmatrix_diag!(K::AbstractVector, k::ConstantKernel, x::AbstractVector)
+    validate_inplace_dims(K, x)
+    return fill!(K, only(k.c))
+end
+function kernelmatrix_diag!(
+    K::AbstractVector, k::ConstantKernel, x::AbstractVector, y::AbstractVector
+)
+    validate_inplace_dims(K, x, y)
+    return fill!(K, only(k.c))
 end
 
 Base.show(io::IO, κ::ConstantKernel) = print(io, "Constant Kernel (c = ", only(κ.c), ")")


### PR DESCRIPTION
This PR adds optimized implementations of `kernelmatrix`, `kernelmatrix!`, `kernelmatrix_diag` and `kernelmatrix_diag!` for `ZeroKernel` and `ConstantKernel`, similar to #438.