### PR TITLE
MOInput Type Stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.3'
+          - '1.6'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.40"
+version = "0.10.41"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/mokernels/moinput.jl
+++ b/src/mokernels/moinput.jl
@@ -53,9 +53,9 @@ As shown above, an `MOInputIsotopicByOutputs` represents a vector of tuples.
 The first `length(x)` elements represent the inputs for the first output, the second
 `length(x)` elements represent the inputs for the second output, etc.
 """
-struct MOInputIsotopicByOutputs{S,T<:AbstractVector{S}} <: AbstractVector{Tuple{S,Int}}
+struct MOInputIsotopicByOutputs{S,T<:AbstractVector{S},Tout_dim<:Integer} <: AbstractVector{Tuple{S,Int}}
     x::T
-    out_dim::Integer
+    out_dim::Tout_dim
 end
 
 const IsotopicMOInputsUnion = Union{MOInputIsotopicByFeatures,MOInputIsotopicByOutputs}

--- a/src/mokernels/moinput.jl
+++ b/src/mokernels/moinput.jl
@@ -7,7 +7,7 @@
 julia> x = [1, 2, 3];
 
 julia> KernelFunctions.MOInputIsotopicByFeatures(x, 2)
-6-element KernelFunctions.MOInputIsotopicByFeatures{Int64, Vector{Int64}}:
+6-element KernelFunctions.MOInputIsotopicByFeatures{Int64, Vector{Int64}, Int64}:
  (1, 1)
  (1, 2)
  (2, 1)
@@ -24,9 +24,9 @@ The first `out_dim` elements represent all outputs for the first input, the seco
 
 See [Inputs for Multiple Outputs](@ref) in the docs for more info.
 """
-struct MOInputIsotopicByFeatures{S,T<:AbstractVector{S}} <: AbstractVector{Tuple{S,Int}}
+struct MOInputIsotopicByFeatures{S,T<:AbstractVector{S},Tout_dim<:Integer} <: AbstractVector{Tuple{S,Int}}
     x::T
-    out_dim::Integer
+    out_dim::Tout_dim
 end
 
 """
@@ -38,7 +38,7 @@ end
 julia> x = [1, 2, 3];
 
 julia> KernelFunctions.MOInputIsotopicByOutputs(x, 2)
-6-element KernelFunctions.MOInputIsotopicByOutputs{Int64, Vector{Int64}}:
+6-element KernelFunctions.MOInputIsotopicByOutputs{Int64, Vector{Int64}, Int64}:
  (1, 1)
  (2, 1)
  (3, 1)
@@ -97,7 +97,7 @@ A data type to accommodate modelling multi-dimensional output data.
 julia> x = [1, 2, 3];
 
 julia> MOInput(x, 2)
-6-element KernelFunctions.MOInputIsotopicByOutputs{Int64, Vector{Int64}}:
+6-element KernelFunctions.MOInputIsotopicByOutputs{Int64, Vector{Int64}, Int64}:
  (1, 1)
  (2, 1)
  (3, 1)
@@ -137,7 +137,7 @@ julia> Y = [1.1 2.1 3.1; 1.2 2.2 3.2]
 julia> inputs, outputs = prepare_isotopic_multi_output_data(x, ColVecs(Y));
 
 julia> inputs
-6-element KernelFunctions.MOInputIsotopicByFeatures{Float64, Vector{Float64}}:
+6-element KernelFunctions.MOInputIsotopicByFeatures{Float64, Vector{Float64}, Int64}:
  (1.0, 1)
  (1.0, 2)
  (2.0, 1)
@@ -185,7 +185,7 @@ julia> Y = [1.1 1.2; 2.1 2.2; 3.1 3.2]
 julia> inputs, outputs = prepare_isotopic_multi_output_data(x, RowVecs(Y));
 
 julia> inputs
-6-element KernelFunctions.MOInputIsotopicByOutputs{Float64, Vector{Float64}}:
+6-element KernelFunctions.MOInputIsotopicByOutputs{Float64, Vector{Float64}, Int64}:
  (1.0, 1)
  (2.0, 1)
  (3.0, 1)

--- a/src/mokernels/moinput.jl
+++ b/src/mokernels/moinput.jl
@@ -53,7 +53,8 @@ As shown above, an `MOInputIsotopicByOutputs` represents a vector of tuples.
 The first `length(x)` elements represent the inputs for the first output, the second
 `length(x)` elements represent the inputs for the second output, etc.
 """
-struct MOInputIsotopicByOutputs{S,T<:AbstractVector{S},Tout_dim<:Integer} <: AbstractVector{Tuple{S,Int}}
+struct MOInputIsotopicByOutputs{S,T<:AbstractVector{S},Tout_dim<:Integer} <:
+       AbstractVector{Tuple{S,Int}}
     x::T
     out_dim::Tout_dim
 end

--- a/test/mokernels/moinput.jl
+++ b/test/mokernels/moinput.jl
@@ -26,6 +26,7 @@
         @test ibo[5] == (x[1], 2)
         @test ibo[7] == (x[3], 2)
         @test all([(x_, i) for i in 1:3 for x_ in x] .== ibo)
+        @inferred getindex(ibo, 1)
     end
 
     @testset "isotopicbyfeatures" begin
@@ -46,6 +47,7 @@
         @test ibf[5] == (x[2], 2)
         @test ibf[7] == (x[3], 1)
         @test all([(x_, i) for x_ in x for i in 1:3] .== ibf)
+        @inferred getindex(ibf, 1)
     end
 
     @testset "prepare_isotopic_multi_output_data" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,78 +60,78 @@ const GROUP = get(ENV, "GROUP", "")
 include("test_utils.jl")
 
 @testset "KernelFunctions" begin
-    if GROUP == "" || GROUP == "Transform"
-        @testset "transform" begin
-            include("transform/transform.jl")
-            print(" ")
-            include("transform/scaletransform.jl")
-            print(" ")
-            include("transform/ardtransform.jl")
-            print(" ")
-            include("transform/lineartransform.jl")
-            print(" ")
-            include("transform/functiontransform.jl")
-            print(" ")
-            include("transform/selecttransform.jl")
-            print(" ")
-            include("transform/chaintransform.jl")
-            print(" ")
-            include("transform/periodic_transform.jl")
-            print(" ")
-            include("transform/with_lengthscale.jl")
-            print(" ")
-        end
-        @info "Ran tests on Transform"
-    end
+    # if GROUP == "" || GROUP == "Transform"
+    #     @testset "transform" begin
+    #         include("transform/transform.jl")
+    #         print(" ")
+    #         include("transform/scaletransform.jl")
+    #         print(" ")
+    #         include("transform/ardtransform.jl")
+    #         print(" ")
+    #         include("transform/lineartransform.jl")
+    #         print(" ")
+    #         include("transform/functiontransform.jl")
+    #         print(" ")
+    #         include("transform/selecttransform.jl")
+    #         print(" ")
+    #         include("transform/chaintransform.jl")
+    #         print(" ")
+    #         include("transform/periodic_transform.jl")
+    #         print(" ")
+    #         include("transform/with_lengthscale.jl")
+    #         print(" ")
+    #     end
+    #     @info "Ran tests on Transform"
+    # end
 
-    if GROUP == "" || GROUP == "BaseKernels"
-        @testset "basekernels" begin
-            include("basekernels/constant.jl")
-            print(" ")
-            include("basekernels/cosine.jl")
-            print(" ")
-            include("basekernels/exponential.jl")
-            print(" ")
-            include("basekernels/exponentiated.jl")
-            print(" ")
-            include("basekernels/fbm.jl")
-            print(" ")
-            include("basekernels/gabor.jl")
-            print(" ")
-            include("basekernels/matern.jl")
-            print(" ")
-            include("basekernels/nn.jl")
-            print(" ")
-            include("basekernels/periodic.jl")
-            print(" ")
-            include("basekernels/piecewisepolynomial.jl")
-            print(" ")
-            include("basekernels/polynomial.jl")
-            print(" ")
-            include("basekernels/rational.jl")
-            print(" ")
-            include("basekernels/sm.jl")
-            print(" ")
-            include("basekernels/wiener.jl")
-            print(" ")
-        end
-        @info "Ran tests on BaseKernel"
-    end
+    # if GROUP == "" || GROUP == "BaseKernels"
+    #     @testset "basekernels" begin
+    #         include("basekernels/constant.jl")
+    #         print(" ")
+    #         include("basekernels/cosine.jl")
+    #         print(" ")
+    #         include("basekernels/exponential.jl")
+    #         print(" ")
+    #         include("basekernels/exponentiated.jl")
+    #         print(" ")
+    #         include("basekernels/fbm.jl")
+    #         print(" ")
+    #         include("basekernels/gabor.jl")
+    #         print(" ")
+    #         include("basekernels/matern.jl")
+    #         print(" ")
+    #         include("basekernels/nn.jl")
+    #         print(" ")
+    #         include("basekernels/periodic.jl")
+    #         print(" ")
+    #         include("basekernels/piecewisepolynomial.jl")
+    #         print(" ")
+    #         include("basekernels/polynomial.jl")
+    #         print(" ")
+    #         include("basekernels/rational.jl")
+    #         print(" ")
+    #         include("basekernels/sm.jl")
+    #         print(" ")
+    #         include("basekernels/wiener.jl")
+    #         print(" ")
+    #     end
+    #     @info "Ran tests on BaseKernel"
+    # end
 
-    if GROUP == "" || GROUP == "Kernels"
-        @testset "kernels" begin
-            include("kernels/kernelproduct.jl")
-            include("kernels/kernelsum.jl")
-            include("kernels/kerneltensorproduct.jl")
-            include("kernels/overloads.jl")
-            include("kernels/scaledkernel.jl")
-            include("kernels/transformedkernel.jl")
-            include("kernels/normalizedkernel.jl")
-            include("kernels/neuralkernelnetwork.jl")
-            include("kernels/gibbskernel.jl")
-        end
-        @info "Ran tests on Kernel"
-    end
+    # if GROUP == "" || GROUP == "Kernels"
+    #     @testset "kernels" begin
+    #         include("kernels/kernelproduct.jl")
+    #         include("kernels/kernelsum.jl")
+    #         include("kernels/kerneltensorproduct.jl")
+    #         include("kernels/overloads.jl")
+    #         include("kernels/scaledkernel.jl")
+    #         include("kernels/transformedkernel.jl")
+    #         include("kernels/normalizedkernel.jl")
+    #         include("kernels/neuralkernelnetwork.jl")
+    #         include("kernels/gibbskernel.jl")
+    #     end
+    #     @info "Ran tests on Kernel"
+    # end
 
     if GROUP == "" || GROUP == "MultiOutput"
         @testset "multi_output" begin
@@ -147,28 +147,28 @@ include("test_utils.jl")
     if GROUP == "" || GROUP == "Others"
         include("utils.jl")
 
-        @testset "distances" begin
-            include("distances/pairwise.jl")
-            include("distances/dotproduct.jl")
-            include("distances/delta.jl")
-            include("distances/sinus.jl")
-        end
-        @info "Ran tests on Distances"
+        # @testset "distances" begin
+        #     include("distances/pairwise.jl")
+        #     include("distances/dotproduct.jl")
+        #     include("distances/delta.jl")
+        #     include("distances/sinus.jl")
+        # end
+        # @info "Ran tests on Distances"
 
-        @testset "matrix" begin
-            include("matrix/kernelmatrix.jl")
-            include("matrix/kernelkroneckermat.jl")
-            include("matrix/kernelpdmat.jl")
-        end
-        @info "Ran tests on matrix"
+        # @testset "matrix" begin
+        #     include("matrix/kernelmatrix.jl")
+        #     include("matrix/kernelkroneckermat.jl")
+        #     include("matrix/kernelpdmat.jl")
+        # end
+        # @info "Ran tests on matrix"
 
-        @testset "approximations" begin
-            include("approximations/nystrom.jl")
-        end
+        # @testset "approximations" begin
+        #     include("approximations/nystrom.jl")
+        # end
 
-        include("generic.jl")
-        include("chainrules.jl")
-        include("zygoterules.jl")
+        # include("generic.jl")
+        # include("chainrules.jl")
+        # include("zygoterules.jl")
 
         @testset "doctests" begin
             DocMeta.setdocmeta!(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,78 +60,78 @@ const GROUP = get(ENV, "GROUP", "")
 include("test_utils.jl")
 
 @testset "KernelFunctions" begin
-    # if GROUP == "" || GROUP == "Transform"
-    #     @testset "transform" begin
-    #         include("transform/transform.jl")
-    #         print(" ")
-    #         include("transform/scaletransform.jl")
-    #         print(" ")
-    #         include("transform/ardtransform.jl")
-    #         print(" ")
-    #         include("transform/lineartransform.jl")
-    #         print(" ")
-    #         include("transform/functiontransform.jl")
-    #         print(" ")
-    #         include("transform/selecttransform.jl")
-    #         print(" ")
-    #         include("transform/chaintransform.jl")
-    #         print(" ")
-    #         include("transform/periodic_transform.jl")
-    #         print(" ")
-    #         include("transform/with_lengthscale.jl")
-    #         print(" ")
-    #     end
-    #     @info "Ran tests on Transform"
-    # end
+    if GROUP == "" || GROUP == "Transform"
+        @testset "transform" begin
+            include("transform/transform.jl")
+            print(" ")
+            include("transform/scaletransform.jl")
+            print(" ")
+            include("transform/ardtransform.jl")
+            print(" ")
+            include("transform/lineartransform.jl")
+            print(" ")
+            include("transform/functiontransform.jl")
+            print(" ")
+            include("transform/selecttransform.jl")
+            print(" ")
+            include("transform/chaintransform.jl")
+            print(" ")
+            include("transform/periodic_transform.jl")
+            print(" ")
+            include("transform/with_lengthscale.jl")
+            print(" ")
+        end
+        @info "Ran tests on Transform"
+    end
 
-    # if GROUP == "" || GROUP == "BaseKernels"
-    #     @testset "basekernels" begin
-    #         include("basekernels/constant.jl")
-    #         print(" ")
-    #         include("basekernels/cosine.jl")
-    #         print(" ")
-    #         include("basekernels/exponential.jl")
-    #         print(" ")
-    #         include("basekernels/exponentiated.jl")
-    #         print(" ")
-    #         include("basekernels/fbm.jl")
-    #         print(" ")
-    #         include("basekernels/gabor.jl")
-    #         print(" ")
-    #         include("basekernels/matern.jl")
-    #         print(" ")
-    #         include("basekernels/nn.jl")
-    #         print(" ")
-    #         include("basekernels/periodic.jl")
-    #         print(" ")
-    #         include("basekernels/piecewisepolynomial.jl")
-    #         print(" ")
-    #         include("basekernels/polynomial.jl")
-    #         print(" ")
-    #         include("basekernels/rational.jl")
-    #         print(" ")
-    #         include("basekernels/sm.jl")
-    #         print(" ")
-    #         include("basekernels/wiener.jl")
-    #         print(" ")
-    #     end
-    #     @info "Ran tests on BaseKernel"
-    # end
+    if GROUP == "" || GROUP == "BaseKernels"
+        @testset "basekernels" begin
+            include("basekernels/constant.jl")
+            print(" ")
+            include("basekernels/cosine.jl")
+            print(" ")
+            include("basekernels/exponential.jl")
+            print(" ")
+            include("basekernels/exponentiated.jl")
+            print(" ")
+            include("basekernels/fbm.jl")
+            print(" ")
+            include("basekernels/gabor.jl")
+            print(" ")
+            include("basekernels/matern.jl")
+            print(" ")
+            include("basekernels/nn.jl")
+            print(" ")
+            include("basekernels/periodic.jl")
+            print(" ")
+            include("basekernels/piecewisepolynomial.jl")
+            print(" ")
+            include("basekernels/polynomial.jl")
+            print(" ")
+            include("basekernels/rational.jl")
+            print(" ")
+            include("basekernels/sm.jl")
+            print(" ")
+            include("basekernels/wiener.jl")
+            print(" ")
+        end
+        @info "Ran tests on BaseKernel"
+    end
 
-    # if GROUP == "" || GROUP == "Kernels"
-    #     @testset "kernels" begin
-    #         include("kernels/kernelproduct.jl")
-    #         include("kernels/kernelsum.jl")
-    #         include("kernels/kerneltensorproduct.jl")
-    #         include("kernels/overloads.jl")
-    #         include("kernels/scaledkernel.jl")
-    #         include("kernels/transformedkernel.jl")
-    #         include("kernels/normalizedkernel.jl")
-    #         include("kernels/neuralkernelnetwork.jl")
-    #         include("kernels/gibbskernel.jl")
-    #     end
-    #     @info "Ran tests on Kernel"
-    # end
+    if GROUP == "" || GROUP == "Kernels"
+        @testset "kernels" begin
+            include("kernels/kernelproduct.jl")
+            include("kernels/kernelsum.jl")
+            include("kernels/kerneltensorproduct.jl")
+            include("kernels/overloads.jl")
+            include("kernels/scaledkernel.jl")
+            include("kernels/transformedkernel.jl")
+            include("kernels/normalizedkernel.jl")
+            include("kernels/neuralkernelnetwork.jl")
+            include("kernels/gibbskernel.jl")
+        end
+        @info "Ran tests on Kernel"
+    end
 
     if GROUP == "" || GROUP == "MultiOutput"
         @testset "multi_output" begin
@@ -147,28 +147,28 @@ include("test_utils.jl")
     if GROUP == "" || GROUP == "Others"
         include("utils.jl")
 
-        # @testset "distances" begin
-        #     include("distances/pairwise.jl")
-        #     include("distances/dotproduct.jl")
-        #     include("distances/delta.jl")
-        #     include("distances/sinus.jl")
-        # end
-        # @info "Ran tests on Distances"
+        @testset "distances" begin
+            include("distances/pairwise.jl")
+            include("distances/dotproduct.jl")
+            include("distances/delta.jl")
+            include("distances/sinus.jl")
+        end
+        @info "Ran tests on Distances"
 
-        # @testset "matrix" begin
-        #     include("matrix/kernelmatrix.jl")
-        #     include("matrix/kernelkroneckermat.jl")
-        #     include("matrix/kernelpdmat.jl")
-        # end
-        # @info "Ran tests on matrix"
+        @testset "matrix" begin
+            include("matrix/kernelmatrix.jl")
+            include("matrix/kernelkroneckermat.jl")
+            include("matrix/kernelpdmat.jl")
+        end
+        @info "Ran tests on matrix"
 
-        # @testset "approximations" begin
-        #     include("approximations/nystrom.jl")
-        # end
+        @testset "approximations" begin
+            include("approximations/nystrom.jl")
+        end
 
-        # include("generic.jl")
-        # include("chainrules.jl")
-        # include("zygoterules.jl")
+        include("generic.jl")
+        include("chainrules.jl")
+        include("zygoterules.jl")
 
         @testset "doctests" begin
             DocMeta.setdocmeta!(

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -63,7 +63,7 @@
             @test back(ones(size(X)))[1].X == ones(size(X))
         end
 
-        if VERSION >= v"1.6"
+        if VERSION >= v"1.7"
             @testset "Zygote type-inference" begin
                 ctx = NoContext()
                 x = ColVecs(randn(2, 4))


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
Makes the type of `out_dim` field of `MOInput` a type parameter of `MOInput`. This has been done in a non-breaking way.

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->
See summary
<!-- A clear and concise description of the contents of this pull request. -->
* ...

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/pull/405 consides an alternative approach in which the type is constrained to `Int`. This has the disadvantage of being more constrained, and constituting a break change. The potential advantage over the approach used here is slight changes in compile time, but my instinct is that these will be negligible.

**Breaking changes**
<!-- If this PR breaks backwards-compatibility, please start the PR title with `**BREAKING**`! -->
<!-- In this section, describe any changes that are not backwards-compatible, -->
<!-- why it is worth breaking backwards compatiblity, -->
<!-- and how a user would have to address these changes in their downstream code. -->
None
