### PR TITLE
Fix Matern Grads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Manifest.toml
 coverage/
 .DS_store
+dev

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.45"
+version = "0.10.46"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/basekernels/matern.jl
+++ b/src/basekernels/matern.jl
@@ -37,14 +37,15 @@ MaternKernel(; nu::Real=1.5, ν::Real=nu, metric=Euclidean()) = MaternKernel(ν,
 
 @functor MaternKernel
 
-@inline function kappa(k::MaternKernel, d::Real)
-    result = _matern(only(k.ν), d)
-    return ifelse(iszero(d), one(result), result)
-end
+@inline kappa(k::MaternKernel, d::Real) = _matern(only(k.ν), d)
 
 function _matern(ν::Real, d::Real)
-    y = sqrt(2ν) * d
-    return exp((one(d) - ν) * logtwo - loggamma(ν) + ν * log(y) + log(besselk(ν, y)))
+    if iszero(d)
+        return one(d)
+    else
+        y = sqrt(2ν) * d
+        return exp((one(d) - ν) * logtwo - loggamma(ν) + ν * log(y) + log(besselk(ν, y)))
+    end
 end
 
 metric(k::MaternKernel) = k.metric

--- a/src/basekernels/matern.jl
+++ b/src/basekernels/matern.jl
@@ -44,7 +44,8 @@ function _matern(ν::Real, d::Real)
         return one(d)
     else
         y = sqrt(2ν) * d
-        return exp((one(d) - ν) * logtwo - loggamma(ν) + ν * log(y) + log(besselk(ν, y)))
+        b = log(besselk(ν, y))
+        return exp((one(d) - ν) * oftype(y, logtwo) - loggamma(ν) + ν * log(y) + b)
     end
 end
 


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
<!-- Summary of what & why - explain your motivation and/or link to any GitHub issues this relates to -->

We've been seeing test failures for AD with the `MaternKernel`. This fixes these.


**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
Modifies the implementation of the `kappa` function for the `MaternKernel` to utilise `if ... else ... end` instead of `ifelse.` The reason that this fixes the problem is that, if `iszero(d)`, the branch which calls the bessel function etc (rather that the one that just returns `1`) has some `NaN`s and some `Inf`s floating around in it.
The `ifelse` branch evaluates this branch-with-`NaN`s, and when Zygote is performing the reverse pass, this `NaN` somehow gets propagated backwards.
Conversely, `if ... else ... end` entirely avoids computing any `NaN`s, thereby avoiding the problem.

This has the potential downside of yielding worse performance under Zygote, the `MaternKernel` performance was already quite bad, so I don't view this as a problem (it might not even make it much worse tbh).

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
The solution that's defnitely going to work + be performant here would be a custom rule, but I don't have the time, and I don't know that this can be improved without sorting out the `besselk` `rrule` anyway.

**Breaking changes**
<!-- If this PR breaks backwards-compatibility, please start the PR title with `**BREAKING**`! -->
<!-- In this section, describe any changes that are not backwards-compatible, -->
<!-- why it is worth breaking backwards compatiblity, -->
<!-- and how a user would have to address these changes in their downstream code. -->
Not breaking.