### PR TITLE
Add lengthscale parameter to SquareExp Kernel

### DIFF
--- a/src/basekernels/exponential.jl
+++ b/src/basekernels/exponential.jl
@@ -1,27 +1,28 @@
 """
-    SqExponentialKernel(; metric=Euclidean())
+    SqExponentialKernel(; metric=Euclidean(), ℓ = 1.0)
 
-Squared exponential kernel with respect to the `metric`.
+Squared exponential kernel with respect to the `metric` and with a characteristic lengthscale `ℓ`.
 
 # Definition
 
 For inputs ``x, x'`` and metric ``d(\\cdot, \\cdot)``, the squared exponential kernel is
 defined as
 ```math
-k(x, x') = \\exp\\bigg(- \\frac{d(x, x')^2}{2}\\bigg).
+k(x, x') = \\exp\\bigg(- \\frac{d(x, x')^2}{2\\ell}\\bigg).
 ```
-By default, ``d`` is the Euclidean metric ``d(x, x') = \\|x - x'\\|_2``.
+By default, ``d`` is the Euclidean metric ``d(x, x') = \\|x - x'\\|_2`` and ``\\ell = 1``.
 
 See also: [`GammaExponentialKernel`](@ref)
 """
-struct SqExponentialKernel{M} <: SimpleKernel
+struct SqExponentialKernel{M,lT<:Real} <: SimpleKernel
     metric::M
+    lengthscale::lT
 end
 
-SqExponentialKernel(; metric=Euclidean()) = SqExponentialKernel(metric)
+SqExponentialKernel(; metric=Euclidean(), ℓ=1.0) = SqExponentialKernel(metric, ℓ)
 
-kappa(::SqExponentialKernel, d::Real) = exp(-d^2 / 2)
-kappa(::SqExponentialKernel{<:Euclidean}, d²::Real) = exp(-d² / 2)
+kappa(k::SqExponentialKernel, d::Real) = exp(-d^2 / (2 * k.lengthscale))
+kappa(k::SqExponentialKernel{<:Euclidean}, d²::Real) = exp(-d² / (2 * k.lengthscale))
 
 metric(k::SqExponentialKernel) = k.metric
 metric(::SqExponentialKernel{<:Euclidean}) = SqEuclidean()
@@ -29,7 +30,7 @@ metric(::SqExponentialKernel{<:Euclidean}) = SqEuclidean()
 iskroncompatible(::SqExponentialKernel) = true
 
 function Base.show(io::IO, k::SqExponentialKernel)
-    return print(io, "Squared Exponential Kernel (metric = ", k.metric, ")")
+    return print(io, "Squared Exponential Kernel (metric = ", k.metric, ", ℓ = ", k.lengthscale, ")")
 end
 
 ## Aliases ##

--- a/src/basekernels/exponential.jl
+++ b/src/basekernels/exponential.jl
@@ -30,7 +30,9 @@ metric(::SqExponentialKernel{<:Euclidean}) = SqEuclidean()
 iskroncompatible(::SqExponentialKernel) = true
 
 function Base.show(io::IO, k::SqExponentialKernel)
-    return print(io, "Squared Exponential Kernel (metric = ", k.metric, ", ℓ = ", k.lengthscale, ")")
+    return print(
+        io, "Squared Exponential Kernel (metric = ", k.metric, ", ℓ = ", k.lengthscale, ")"
+    )
 end
 
 ## Aliases ##

--- a/test/basekernels/exponential.jl
+++ b/test/basekernels/exponential.jl
@@ -12,12 +12,17 @@
         @test RBFKernel == SqExponentialKernel
         @test GaussianKernel == SqExponentialKernel
         @test SEKernel == SqExponentialKernel
-        @test repr(k) == "Squared Exponential Kernel (metric = Euclidean(0.0))"
+        @test repr(k) == "Squared Exponential Kernel (metric = Euclidean(0.0), ℓ = 1.0)"
         @test KernelFunctions.iskroncompatible(k) == true
 
         k2 = SqExponentialKernel(; metric=WeightedEuclidean(ones(3)))
         @test metric(k2) isa WeightedEuclidean
         @test k2(v1, v2) ≈ k(v1, v2)
+
+        k3 = SqExponentialKernel(; ℓ=π)
+        @test k3.lengthscale == π
+        @test kappa(k3, x) ≈ exp(-x / 2π)
+        @test k3(v1, v2) ≈ exp(-norm(v1 - v2)^2 / 2π)
 
         # Standardised tests.
         TestUtils.test_interface(k)


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
<!-- Summary of what & why - explain your motivation and/or link to any GitHub issues this relates to -->
This PR adds a `lengthscale` parameter to the `SqExponentialKernel`, making it more flexible.

[1] C. E. Rasmussen and C. K. I. Williams, Gaussian processes for machine learning. Cambridge, Mass: MIT Press, 2006.

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->

According to Eq. (4.9) in [1], the Squared-Exponential Kernel (a.k.a. Gaussian Kernel, etc.) has a characteristic lengthscale as a parameter, s.t. 

<img width="160" alt="image" src="https://user-images.githubusercontent.com/18748418/196924596-de3641fb-e710-4574-878e-cbaef6073f1e.png">

, where `r = d(x, y)` is the distance between two points `x` and `y`.
This PR adds this parameter, where `lengthscale = 1.0` by default, recovering the previous state and thus making it compatible with applications already using it.

**Breaking changes**
<!-- If this PR breaks backwards-compatibility, please start the PR title with `**BREAKING**`! -->
<!-- In this section, describe any changes that are not backwards-compatible, -->
<!-- why it is worth breaking backwards compatiblity, -->
<!-- and how a user would have to address these changes in their downstream code. -->
None.