### PR TITLE
Stable version of KernelProduct and added `test_type_stability`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.48"
+version = "0.10.49"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/TestUtils.jl
+++ b/src/TestUtils.jl
@@ -164,9 +164,7 @@ end
 function test_with_type(
     f, rng::AbstractRNG, k::Kernel, ::Type{Vector{T}}; kwargs...
 ) where {T<:Real}
-    return f(
-        k, randn(rng, T, 11), randn(rng, T, 11), randn(rng, T, 13); kwargs...
-    )
+    return f(k, randn(rng, T, 11), randn(rng, T, 11), randn(rng, T, 13); kwargs...)
 end
 
 function test_with_type(

--- a/src/TestUtils.jl
+++ b/src/TestUtils.jl
@@ -116,7 +116,9 @@ test_type_stability(
 Run type stability checks over `k(x,y)` and the different functions of the API (`kernelmatrix`, `kernelmatrix_diag`).
 `x0` and `x1` should be of the same length with different values, while `x0` and `x2` should be of different lengths.
 """
-function test_type_stability(k::Kernel, x0::AbstractVector, x1::AbstractVector, x2::AbstractVector)
+function test_type_stability(
+    k::Kernel, x0::AbstractVector, x1::AbstractVector, x2::AbstractVector
+)
     # Ensure that we have the required inputs.
     @assert length(x0) == length(x1)
     @assert length(x0) ≠ length(x2)

--- a/src/TestUtils.jl
+++ b/src/TestUtils.jl
@@ -106,15 +106,16 @@ function test_interface(rng::AbstractRNG, k::Kernel, T::Type=Float64; kwargs...)
 end
 
 """
-test_type_stability(
-    k::Kernel,
-    x0::AbstractVector,
-    x1::AbstractVector,
-    x2::AbstractVector
-)
+    test_type_stability(
+        k::Kernel,
+        x0::AbstractVector,
+        x1::AbstractVector,
+        x2::AbstractVector,
+    )
 
-Run type stability checks over `k(x,y)` and the different functions of the API (`kernelmatrix`, `kernelmatrix_diag`).
-`x0` and `x1` should be of the same length with different values, while `x0` and `x2` should be of different lengths.
+Run type stability checks over `k(x,y)` and the different functions of the API 
+(`kernelmatrix`, `kernelmatrix_diag`). `x0` and `x1` should be of the same 
+length with different values, while `x0` and `x2` should be of different lengths.
 """
 function test_type_stability(
     k::Kernel, x0::AbstractVector, x1::AbstractVector, x2::AbstractVector
@@ -122,7 +123,6 @@ function test_type_stability(
     # Ensure that we have the required inputs.
     @assert length(x0) == length(x1)
     @assert length(x0) ≠ length(x2)
-    # @test @inferred(k(first(x0), first(x1))) isa Real
     @test @inferred(kernelmatrix(k, x0)) isa AbstractMatrix
     @test @inferred(kernelmatrix(k, x0, x2)) isa AbstractMatrix
     @test @inferred(kernelmatrix_diag(k, x0)) isa AbstractVector

--- a/src/TestUtils.jl
+++ b/src/TestUtils.jl
@@ -138,9 +138,10 @@ function test_type_stability(rng::AbstractRNG, k::Kernel, ::Type{T}; kwargs...) 
 end
 
 """
-    test_with_type(f, rng::AbstractRNG, k::Kernel, ::Type{T}; kwargs...) where {T<:Real}
+    test_with_type(f, rng::AbstractRNG, k::Kernel, ::Type{T}; kwargs...) where {T}
 
-Run the functions `f`, (for example [`test_interface`](@ref) or [`test_type_stable`](@ref)) for randomly generated inputs of types `Vector{T}`,
+Run the functions `f`, (for example [`test_interface`](@ref) or
+[`test_type_stable`](@ref)) for randomly generated inputs of types `Vector{T}`,
 `Vector{Vector{T}}`, `ColVecs{T}`, and `RowVecs{T}`.
 
 For other input types, please provide the data manually.

--- a/src/TestUtils.jl
+++ b/src/TestUtils.jl
@@ -86,7 +86,6 @@ function test_interface(
     @test kernelmatrix_diag!(tmp_diag, k, x0, x1) ≈ kernelmatrix_diag(k, x0, x1)
 end
 
-
 """
     test_interface([rng::AbstractRNG], k::Kernel, ::Type{T}=Float64; kwargs...) where {T}
 

--- a/src/kernels/kernelproduct.jl
+++ b/src/kernels/kernelproduct.jl
@@ -45,8 +45,11 @@ Base.length(k::KernelProduct) = length(k.kernels)
 
 (κ::KernelProduct)(x, y) = prod(k(x, y) for k in κ.kernels)
 
+_hadamard(f::Tf, x::Tuple) where {Tf} = f(first(x)) .* _hadamard(f, Base.tail(x))
+_hadamard(f::Tf, x::Tuple{Tx}) where {Tf,Tx} = f(only(x))
+
 function kernelmatrix(κ::KernelProduct, x::AbstractVector)
-    return reduce(hadamard, kernelmatrix(k, x) for k in κ.kernels)
+    return _hadamard(Base.Fix2(kernelmatrix, x), κ.kernels)
 end
 
 function kernelmatrix(κ::KernelProduct, x::AbstractVector, y::AbstractVector)

--- a/src/kernels/kernelproduct.jl
+++ b/src/kernels/kernelproduct.jl
@@ -45,11 +45,11 @@ Base.length(k::KernelProduct) = length(k.kernels)
 
 (κ::KernelProduct)(x, y) = prod(k(x, y) for k in κ.kernels)
 
-_hadamard(f::Tf, x::Tuple) where {Tf} = f(first(x)) .* _hadamard(f, Base.tail(x))
-_hadamard(f::Tf, x::Tuple{Tx}) where {Tf,Tx} = f(only(x))
+_hadamard(f, ks::Tuple, x) = f(first(ks), x) .* _hadamard(f, Base.tail(ks), x)
+_hadamard(f, ks::Tuple{Tx}, x) where {Tx} = f(only(ks), x)
 
 function kernelmatrix(κ::KernelProduct, x::AbstractVector)
-    return _hadamard(Base.Fix2(kernelmatrix, x), κ.kernels)
+    return _hadamard(kernelmatrix, κ.kernels, x)
 end
 
 function kernelmatrix(κ::KernelProduct, x::AbstractVector, y::AbstractVector)

--- a/src/kernels/kernelproduct.jl
+++ b/src/kernels/kernelproduct.jl
@@ -45,7 +45,9 @@ Base.length(k::KernelProduct) = length(k.kernels)
 
 (κ::KernelProduct)(x, y) = prod(k(x, y) for k in κ.kernels)
 
-_hadamard(f, ks::Tuple, args...) = f(first(ks), args...) .* _hadamard(f, Base.tail(ks), args...)
+function _hadamard(f, ks::Tuple, args...)
+    return f(first(ks), args...) .* _hadamard(f, Base.tail(ks), args...)
+end
 _hadamard(f, ks::Tuple{Tx}, args...) where {Tx} = f(only(ks), args...)
 
 (κ::KernelProduct)(x, y) = _hadamard((k, x, y) -> k(x, y), κ.kernels, x, y)

--- a/src/kernels/kernelproduct.jl
+++ b/src/kernels/kernelproduct.jl
@@ -45,19 +45,21 @@ Base.length(k::KernelProduct) = length(k.kernels)
 
 (κ::KernelProduct)(x, y) = prod(k(x, y) for k in κ.kernels)
 
-_hadamard(f, ks::Tuple, x) = f(first(ks), x) .* _hadamard(f, Base.tail(ks), x)
-_hadamard(f, ks::Tuple{Tx}, x) where {Tx} = f(only(ks), x)
+_hadamard(f, ks::Tuple, args...) = f(first(ks), args...) .* _hadamard(f, Base.tail(ks), args...)
+_hadamard(f, ks::Tuple{Tx}, args...) where {Tx} = f(only(ks), args...)
+
+(κ::KernelProduct)(x, y) = _hadamard((k, x, y) -> k(x, y), κ.kernels, x, y)
 
 function kernelmatrix(κ::KernelProduct, x::AbstractVector)
     return _hadamard(kernelmatrix, κ.kernels, x)
 end
 
 function kernelmatrix(κ::KernelProduct, x::AbstractVector, y::AbstractVector)
-    return reduce(hadamard, kernelmatrix(k, x, y) for k in κ.kernels)
+    return _hadamard(kernelmatrix, κ.kernels, x, y)
 end
 
 function kernelmatrix_diag(κ::KernelProduct, x::AbstractVector)
-    return reduce(hadamard, kernelmatrix_diag(k, x) for k in κ.kernels)
+    return _hadamard(kernelmatrix_diag, κ.kernels, x, y)
 end
 
 function kernelmatrix_diag(κ::KernelProduct, x::AbstractVector, y::AbstractVector)

--- a/src/kernels/kernelproduct.jl
+++ b/src/kernels/kernelproduct.jl
@@ -59,11 +59,11 @@ function kernelmatrix(κ::KernelProduct, x::AbstractVector, y::AbstractVector)
 end
 
 function kernelmatrix_diag(κ::KernelProduct, x::AbstractVector)
-    return _hadamard(kernelmatrix_diag, κ.kernels, x, y)
+    return _hadamard(kernelmatrix_diag, κ.kernels, x)
 end
 
 function kernelmatrix_diag(κ::KernelProduct, x::AbstractVector, y::AbstractVector)
-    return reduce(hadamard, kernelmatrix_diag(k, x, y) for k in κ.kernels)
+    return _hadamard(kernelmatrix_diag, κ.kernels, x, y)
 end
 
 function Base.show(io::IO, κ::KernelProduct)

--- a/src/kernels/kernelsum.jl
+++ b/src/kernels/kernelsum.jl
@@ -43,7 +43,7 @@ end
 
 Base.length(k::KernelSum) = length(k.kernels)
 
-_sum(f, ks::Tuple, args...) = f(first(ks), args...) + _sum(f, Base.tail(ks). args...)
+_sum(f, ks::Tuple, args...) = f(first(ks), args...) + _sum(f, Base.tail(ks), args...)
 _sum(f, ks::Tuple{Tx}, args...) where {Tx} = f(only(ks), args...)
 
 (κ::KernelSum)(x, y) = _sum((k, x, y) -> k(x, y), κ.kernels, x, y)

--- a/src/kernels/kernelsum.jl
+++ b/src/kernels/kernelsum.jl
@@ -43,21 +43,21 @@ end
 
 Base.length(k::KernelSum) = length(k.kernels)
 
-_sum(f::Tf, x::Tuple) where {Tf} = f(x[1]) + _sum(f, Base.tail(x))
-_sum(f::Tf, x::Tuple{Tx}) where {Tf,Tx} = f(x[1])
+_sum(f, ks::Tuple, args...) = f(first(ks), args...) + _sum(f, Base.tail(ks). args...)
+_sum(f, ks::Tuple{Tx}, args...) where {Tx} = f(only(ks), args...)
 
-(κ::KernelSum)(x, y) = _sum(k -> k(x, y), κ.kernels)
+(κ::KernelSum)(x, y) = _sum((k, x, y) -> k(x, y), κ.kernels, x, y)
 
 function kernelmatrix(κ::KernelSum, x::AbstractVector)
-    return _sum(Base.Fix2(kernelmatrix, x), κ.kernels)
+    return _sum(kernelmatrix, κ.kernels, x)
 end
 
 function kernelmatrix(κ::KernelSum, x::AbstractVector, y::AbstractVector)
-    return _sum(k -> kernelmatrix(k, x, y), κ.kernels)
+    return _sum(kernelmatrix, κ.kernels, x, y)
 end
 
 function kernelmatrix_diag(κ::KernelSum, x::AbstractVector)
-    return _sum(Base.Fix2(kernelmatrix_diag, x), κ.kernels)
+    return _sum(k -> kernelmatrix_diag(k, x), κ.kernels)
 end
 
 function kernelmatrix_diag(κ::KernelSum, x::AbstractVector, y::AbstractVector)

--- a/src/kernels/kernelsum.jl
+++ b/src/kernels/kernelsum.jl
@@ -48,7 +48,6 @@ _sum(f, ks::Tuple{Tx}, args...) where {Tx} = f(only(ks), args...)
 
 (κ::KernelSum)(x, y) = _sum((k, x, y) -> k(x, y), κ.kernels, x, y)
 
-
 function kernelmatrix(κ::KernelSum, x::AbstractVector)
     return _sum(kernelmatrix, κ.kernels, x)
 end

--- a/src/kernels/kernelsum.jl
+++ b/src/kernels/kernelsum.jl
@@ -48,6 +48,7 @@ _sum(f, ks::Tuple{Tx}, args...) where {Tx} = f(only(ks), args...)
 
 (κ::KernelSum)(x, y) = _sum((k, x, y) -> k(x, y), κ.kernels, x, y)
 
+
 function kernelmatrix(κ::KernelSum, x::AbstractVector)
     return _sum(kernelmatrix, κ.kernels, x)
 end
@@ -57,11 +58,11 @@ function kernelmatrix(κ::KernelSum, x::AbstractVector, y::AbstractVector)
 end
 
 function kernelmatrix_diag(κ::KernelSum, x::AbstractVector)
-    return _sum(k -> kernelmatrix_diag(k, x), κ.kernels)
+    return _sum(kernelmatrix_diag, κ.kernels, x)
 end
 
 function kernelmatrix_diag(κ::KernelSum, x::AbstractVector, y::AbstractVector)
-    return _sum(k -> kernelmatrix_diag(k, x, y), κ.kernels)
+    return _sum(kernelmatrix_diag, κ.kernels, x, y)
 end
 
 function Base.show(io::IO, κ::KernelSum)

--- a/test/kernels/kernelproduct.jl
+++ b/test/kernels/kernelproduct.jl
@@ -10,8 +10,8 @@
     )
 
     # Standardised tests.
-    TestUtils.test_interface(k, Float64)
-    TestUtils.test_interface(ConstantKernel(; c=1.0) * WhiteKernel(), Vector{String})
+    test_interface(k, Float64)
+    test_interface(ConstantKernel(; c=1.0) * WhiteKernel(), Vector{String})
     test_ADs(
         x -> KernelProduct(SqExponentialKernel(), LinearKernel(; c=exp(x[1]))), rand(1)
     )
@@ -20,8 +20,6 @@
     end
     test_params(k1 * k2, (k1, k2))
 
-    nested_k =
-        RBFKernel() * ((LinearKernel() + CosineKernel() * RBFKernel()) ∘ SelectTransform(1))
-    x = RowVecs(rand(10, 2))
-    @test (@inferred kernelmatrix(nested_k, x)) isa Matrix{Float64}
+    nested_k = RBFKernel() * (LinearKernel() + CosineKernel() * RBFKernel())
+    test_type_stability(nested_k)
 end

--- a/test/kernels/kernelproduct.jl
+++ b/test/kernels/kernelproduct.jl
@@ -19,4 +19,8 @@
         KernelProduct(SqExponentialKernel(), LinearKernel(; c=c))
     end
     test_params(k1 * k2, (k1, k2))
+
+    nested_k = RBFKernel() * ((LinearKernel() + CosineKernel() * RBFKernel()) ∘ SelectTransform(1))
+    x = RowVecs(rand(10, 2))
+    @test (@inferred kernelmatrix(nested_k, x)) isa Matrix{Float64}
 end

--- a/test/kernels/kernelproduct.jl
+++ b/test/kernels/kernelproduct.jl
@@ -20,7 +20,8 @@
     end
     test_params(k1 * k2, (k1, k2))
 
-    nested_k = RBFKernel() * ((LinearKernel() + CosineKernel() * RBFKernel()) ∘ SelectTransform(1))
+    nested_k =
+        RBFKernel() * ((LinearKernel() + CosineKernel() * RBFKernel()) ∘ SelectTransform(1))
     x = RowVecs(rand(10, 2))
     @test (@inferred kernelmatrix(nested_k, x)) isa Matrix{Float64}
 end

--- a/test/kernels/kernelsum.jl
+++ b/test/kernels/kernelsum.jl
@@ -4,39 +4,28 @@
     k = KernelSum(k1, k2)
     @test k == KernelSum([k1, k2]) == KernelSum((k1, k2))
     @test length(k) == 2
-    @test string(k) == (
+    @test repr(k) == (
         "Sum of 2 kernels:\n" *
         "\tLinear Kernel (c = 0.0)\n" *
         "\tSquared Exponential Kernel (metric = Euclidean(0.0))"
     )
 
     # Standardised tests.
-    TestUtils.test_interface(k, Float64)
-    TestUtils.test_interface(ConstantKernel(; c=1.5) * WhiteKernel(), Vector{String})
-    test_ADs(x -> KernelSum(SqExponentialKernel(), LinearKernel(; c=exp(x[1]))), rand(1))
-    test_interface_ad_perf(2.4, StableRNG(123456)) do c
-        KernelSum(SqExponentialKernel(), LinearKernel(; c=c))
-    end
+    test_interface(k, Float64)
+    test_interface(ConstantKernel(; c=1.5) + WhiteKernel(), Vector{String})
+    # test_ADs(x -> KernelSum(SqExponentialKernel(), LinearKernel(; c=exp(x[1]))), rand(1))
+    # test_interface_ad_perf(2.4, StableRNG(123456)) do c
+        # KernelSum(SqExponentialKernel(), LinearKernel(; c=c))
+    # end
 
-    test_params(k1 + k2, (k1, k2))
+    # test_params(k1 + k2, (k1, k2))
 
     # Regression tests for https://github.com//issues/458
-    @testset "Type stability" begin
-        function check_type_stability(k)
-            @test (@inferred k(0.1, 0.2)) isa Real
-            x = rand(10)
-            y = rand(10)
-            @test (@inferred kernelmatrix(k, x)) isa Matrix{<:Real}
-            @test (@inferred kernelmatrix(k, x, y)) isa Matrix{<:Real}
-            @test (@inferred kernelmatrix_diag(k, x)) isa Vector{<:Real}
-            @test (@inferred kernelmatrix_diag(k, x, y)) isa Vector{<:Real}
-        end
-        @testset for k in (
-            RBFKernel() + RBFKernel() * LinearKernel(),
-            RBFKernel() + RBFKernel() * ExponentialKernel(),
-            RBFKernel() * (LinearKernel() + ExponentialKernel()),
-        )
-            check_type_stability(k)
-        end
+    @testset for k in (
+        RBFKernel() + RBFKernel() * LinearKernel(),
+        RBFKernel() + RBFKernel() * ExponentialKernel(),
+        RBFKernel() * (LinearKernel() + ExponentialKernel()),
+    )
+        test_type_stability(k)
     end
 end

--- a/test/kernels/kernelsum.jl
+++ b/test/kernels/kernelsum.jl
@@ -13,12 +13,12 @@
     # Standardised tests.
     test_interface(k, Float64)
     test_interface(ConstantKernel(; c=1.5) + WhiteKernel(), Vector{String})
-    # test_ADs(x -> KernelSum(SqExponentialKernel(), LinearKernel(; c=exp(x[1]))), rand(1))
-    # test_interface_ad_perf(2.4, StableRNG(123456)) do c
-        # KernelSum(SqExponentialKernel(), LinearKernel(; c=c))
-    # end
+    test_ADs(x -> KernelSum(SqExponentialKernel(), LinearKernel(; c=exp(x[1]))), rand(1))
+    test_interface_ad_perf(2.4, StableRNG(123456)) do c
+        KernelSum(SqExponentialKernel(), LinearKernel(; c=c))
+    end
 
-    # test_params(k1 + k2, (k1, k2))
+    test_params(k1 + k2, (k1, k2))
 
     # Regression tests for https://github.com//issues/458
     @testset for k in (

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ using Compat: only
 
 using KernelFunctions: SimpleKernel, metric, kappa, ColVecs, RowVecs, TestUtils
 
-using KernelFunctions.TestUtils: test_interface, example_inputs
+using KernelFunctions.TestUtils: test_interface, test_type_stability, example_inputs
 
 # The GROUP is used to run different sets of tests in parallel on the GitHub Actions CI.
 # If you want to introduce a new group, ensure you also add it to .github/workflows/ci.yml


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
This adresses #485  by bringing a similar solution from #459. It goes slightly differently by avoiding a closure entirely.
This also add tests for checking that on the culprit kernel, the type stability is maintained.
Regarding performance, it seems to not change anything (maybe marginally better).

master:
```julia
julia> @btime kernelmatrix($nested_k, $x);
  5.005 μs (23 allocations: 10.94 KiB)
```
this PR:
```julia
julia> @btime kernelmatrix($nested_k, $x);
  4.936 μs (18 allocations: 10.69 KiB)
```

This also refactors a part of `TestUtils.jl` to run with `test_with_type` so that we can reuse this functionality for different tests.


**Breaking changes**
Non-breaking
