### PR TITLE
Remove duplicate definition of KernelProduct

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.49"
+version = "0.10.50"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/kernels/kernelproduct.jl
+++ b/src/kernels/kernelproduct.jl
@@ -43,8 +43,6 @@ end
 
 Base.length(k::KernelProduct) = length(k.kernels)
 
-(κ::KernelProduct)(x, y) = prod(k(x, y) for k in κ.kernels)
-
 function _hadamard(f, ks::Tuple, args...)
     return f(first(ks), args...) .* _hadamard(f, Base.tail(ks), args...)
 end


### PR DESCRIPTION
In the last PR #486 , there was a leftover issue where 
```
(κ::KernelProduct)(x, y)
```
is defined twice.
This removes one of the definitions.