### PR TITLE
Improve Performance of `reduce(hcat, ::ColVecs)` and `reduce(vcat, ::ColVecs)` by specialization

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -94,6 +94,8 @@ Base.setindex!(D::ColVecs, v::AbstractVector, i) = setindex!(D.X, v, :, i)
 
 Base.vcat(a::ColVecs, b::ColVecs) = ColVecs(hcat(a.X, b.X))
 Base.zero(x::ColVecs) = ColVecs(zero(x.X))
+Base.reduce(::typeof(hcat), a::ColVecs) = a.X
+Base.reduce(::typeof(vcat), a::ColVecs) = reshape(a.X, :)
 
 dim(x::ColVecs) = size(x.X, 1)
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -40,6 +40,9 @@
 
         Y = randn(rng, D, N + 1)
         DY = ColVecs(Y)
+
+        @test reduce(vcat, DY) == vcat(DY...)
+        @test reduce(hcat, DY) == hcat(DY...)
         @test KernelFunctions.pairwise(SqEuclidean(), DX) ≈
             pairwise(SqEuclidean(), X; dims=2)
         @test KernelFunctions.pairwise(SqEuclidean(), DX, DY) ≈


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
<!-- Summary of what & why - explain your motivation and/or link to any GitHub issues this relates to -->
The idea is that
```julia
reduce(hcat, ColVecs(X))
```
should in principle be a no-op.

**Proposed changes**
Specialization of `reduce` on `typeof(hcat)` and `typeof(vcat)`.

The drawback is more code. But I added test coverage and it was something very easy to do 🤷 . Whether you want this or not is up to you.
