### PR TITLE
Remove input check for vector of vectors

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -191,7 +191,6 @@ pairwise(d::PreMetric, x::RowVecs, y::ColVecs) = pairwise(d, ColVecs(permutedims
 
 dim(x) = 0 # This is the passes-by-default choice. For a proper check, implement `KernelFunctions.dim` for your datatype.
 dim(x::AbstractVector) = dim(first(x))
-dim(x::AbstractVector{<:AbstractVector{<:Real}}) = length(first(x))
 dim(x::AbstractVector{<:Real}) = 1
 
 function validate_inputs(x, y)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -163,7 +163,7 @@
         @test_throws DimensionMismatch KernelFunctions.validate_inplace_dims(zeros(N2), x)
 
         @test_nowarn KernelFunctions.validate_inputs(x, y)
-        @test_throws DimensionMismatch KernelFunctions.validate_inputs(x⁻, y)
+        @test_nowarn KernelFunctions.validate_inputs(x⁻, y)
 
         @test_nowarn KernelFunctions.validate_inputs(xx, yy)
         @test_nowarn KernelFunctions.validate_inputs(xx⁻, yy)


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
<!-- Summary of what & why - explain your motivation and/or link to any GitHub issues this relates to -->
This attempts to address  #512, which prevents kernels operating on vectors of unequal length from working properly. 

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
* ...
Remove the check on input dimensions when the inputs are vectors of vectors, since there is nothing wrong in principal with having kernels operate on these kinds of inputs.

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
The most obvious alternative would be to implement my own type, wrapping AbstractVector{<:AbstractVector{<:Real}}, but since this change would potentially benefit others with similar needs, a fix in KernelFunctions itself seemed more appropriate. 
**Breaking changes**
<!-- If this PR breaks backwards-compatibility, please start the PR title with `**BREAKING**`! -->
<!-- In this section, describe any changes that are not backwards-compatible, -->
<!-- why it is worth breaking backwards compatiblity, -->
<!-- and how a user would have to address these changes in their downstream code. -->
The main change is that inputs checks that are currently failing would pass. This is potentially breaking, as it is possible that downstream code could rely on these checks. 