### PR TITLE
Make pullback error for ColVecs and RowVecs a bit more informative

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.56"
+version = "0.10.57"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -151,7 +151,7 @@ function ChainRulesCore.rrule(::Type{<:ColVecs}, X::AbstractMatrix)
         return error(
             "Pullback on AbstractVector{<:AbstractVector}.\n" *
             "This might happen if you try to use gradients on the generic `kernelmatrix` or `kernelmatrix_diag`,\n" *
-            "or because some other external computation has acted on `ColVecs` to produce a vector of vectors." *
+            "or because some external computation has acted on `ColVecs` to produce a vector of vectors." *
             "If it is the former, to solve this issue overload `kernelmatrix(_diag)` for your kernel for `ColVecs`",
         )
     end
@@ -164,7 +164,7 @@ function ChainRulesCore.rrule(::Type{<:RowVecs}, X::AbstractMatrix)
         return error(
             "Pullback on AbstractVector{<:AbstractVector}.\n" *
             "This might happen if you try to use gradients on the generic `kernelmatrix` or `kernelmatrix_diag`,\n" *
-            "or because some other external computation has acted on `RowVecs` to produce a vector of vectors." *
+            "or because some external computation has acted on `RowVecs` to produce a vector of vectors." *
             "If it is the former, to solve this issue overload `kernelmatrix(_diag)` for your kernel for `RowVecs`",
         )
     end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -152,7 +152,9 @@ function ChainRulesCore.rrule(::Type{<:ColVecs}, X::AbstractMatrix)
             "Pullback on AbstractVector{<:AbstractVector}.\n" *
             "This might happen if you try to use gradients on the generic `kernelmatrix` or `kernelmatrix_diag`,\n" *
             "or because some external computation has acted on `ColVecs` to produce a vector of vectors." *
-            "If it is the former, to solve this issue overload `kernelmatrix(_diag)` for your kernel for `ColVecs`",
+            "In the former case, to solve this issue overload `kernelmatrix(_diag)` for your kernel for `ColVecs`." *
+            "In the latter case, one needs to track down the `rrule` whose pullback returns a `Vector{Vector{T}}`," *
+            " rather than a `Tangent`, as the cotangent / gradient for `ColVecs` input, and circumvent it."
         )
     end
     return ColVecs(X), ColVecs_pullback

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -150,8 +150,9 @@ function ChainRulesCore.rrule(::Type{<:ColVecs}, X::AbstractMatrix)
     function ColVecs_pullback(::AbstractVector{<:AbstractVector{<:Real}})
         return error(
             "Pullback on AbstractVector{<:AbstractVector}.\n" *
-            "This might happen if you try to use gradients on the generic `kernelmatrix` or `kernelmatrix_diag`.\n" *
-            "To solve this issue overload `kernelmatrix(_diag)` for your kernel for `ColVecs`",
+            "This might happen if you try to use gradients on the generic `kernelmatrix` or `kernelmatrix_diag`,\n" *
+            "or because some other external computation has acted on `ColVecs` to produce a vector of vectors." *
+            "If it is the former, to solve this issue overload `kernelmatrix(_diag)` for your kernel for `ColVecs`",
         )
     end
     return ColVecs(X), ColVecs_pullback
@@ -162,8 +163,9 @@ function ChainRulesCore.rrule(::Type{<:RowVecs}, X::AbstractMatrix)
     function RowVecs_pullback(::AbstractVector{<:AbstractVector{<:Real}})
         return error(
             "Pullback on AbstractVector{<:AbstractVector}.\n" *
-            "This might happen if you try to use gradients on the generic `kernelmatrix` or `kernelmatrix_diag`.\n" *
-            "To solve this issue overload `kernelmatrix(_diag)` for your kernel for `RowVecs`",
+            "This might happen if you try to use gradients on the generic `kernelmatrix` or `kernelmatrix_diag`,\n" *
+            "or because some other external computation has acted on `RowVecs` to produce a vector of vectors." *
+            "If it is the former, to solve this issue overload `kernelmatrix(_diag)` for your kernel for `RowVecs`",
         )
     end
     return RowVecs(X), RowVecs_pullback


### PR DESCRIPTION
The adjoint defined for `ColVecs` and `RowVecs` indicates that the cause of the error might be something internal to KernelFunctions.jl. But other packages are also making use of `ColVecs` and `RowVecs`, e.g. AbstractGPs.jl, which in turn means that issues often encountered in practice are _not_ related to what the adjoint-error indicates, e.g. https://github.com/JuliaGaussianProcesses/AbstractGPs.jl/issues/344

I ran into this yesterday and because of the error message I spent a fair bit of time looking for bugs in the kernel-related code rather than looking elsewhere. Hence the PR:)

My wording in the error message can probably do with an improvement?

EDIT: Oh and why does this adjoint definition exist? Why not just pull back the vector of vectors to a matrix? AFAIK the adjoint is still valid?