### PR TITLE
Fix Matern AD failures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.58"
+version = "0.10.59"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/basekernels/matern.jl
+++ b/src/basekernels/matern.jl
@@ -41,7 +41,8 @@ MaternKernel(; nu::Real=1.5, ν::Real=nu, metric=Euclidean()) = MaternKernel(ν,
 
 function _matern(ν::Real, d::Real)
     if iszero(d)
-        return one(d)
+        c = -ν / (ν - 1)
+        return one(d) + c * d^2 / 2
     else
         y = sqrt(2ν) * d
         b = log(besselk(ν, y))


### PR DESCRIPTION
Should provide a fix for #526 while the issues revolving around Distances/Zygote/ChainRulesCore are still open.