### PR TITLE
Relax allocation test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.8'
+          - '1.6'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.6'
+          - '1.8'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.61"
+version = "0.10.62"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -384,7 +384,7 @@ function test_zygote_perf_heuristic(
             @test_broken fwd[1] == fwd[2]
         end
         if passes[3]
-            @test pb[1] == pb[2]
+            @test abs(pb[1] - pb[2]) ≤ 1
         else
             @test_broken pb[1] == pb[2]
         end


### PR DESCRIPTION
Fixes part of #526. For some reason I have not been able to figure out, starting from Julia 1.9 the allocations in these AD calls can be off by one from call to call. This PR relaxes the test slightly. I think this still serves the original purpose of the test.