### PR TITLE
Remove chainrule and test for `SqMahalanobis`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.59"
+version = "0.10.60"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -21,11 +21,4 @@
     compare_gradient(:Zygote, [x, y]) do xy
         KernelFunctions.Sinus(r)(xy[1], xy[2])
     end
-    if VERSION < v"1.6"
-        @test_broken "Chain rule of SqMahalanobis is broken in Julia pre-1.6"
-    else
-        compare_gradient(:Zygote, [Q, x, y]) do Qxy
-            SqMahalanobis(Qxy[1])(Qxy[2], Qxy[3])
-        end
-    end
 end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -3,8 +3,6 @@
     x = rand(rng, 5)
     y = rand(rng, 5)
     r = rand(rng, 5)
-    Q = Matrix(Cholesky(rand(rng, 5, 5), 'U', 0))
-    @assert isposdef(Q)
 
     compare_gradient(:Zygote, [x, y]) do xy
         Euclidean()(xy[1], xy[2])


### PR DESCRIPTION
Just some cleanup work to remove remnants of the Mahalanobis kernel which has been absent for a while.
- They are no longer needed
- The chainrule is committing type piracy towards Distances.jl (would there be value to move the rule in the extension there?)
- The test is triggering some warnings that are distracting