### PR TITLE
Add `_sum` for `KernelSum{<:AbstractVector}` and associated tests

### DIFF
--- a/src/kernels/kernelsum.jl
+++ b/src/kernels/kernelsum.jl
@@ -45,6 +45,7 @@ Base.length(k::KernelSum) = length(k.kernels)
 
 _sum(f, ks::Tuple, args...) = f(first(ks), args...) + _sum(f, Base.tail(ks), args...)
 _sum(f, ks::Tuple{Tx}, args...) where {Tx} = f(only(ks), args...)
+_sum(f, ks::AbstractVector, args...) = sum(k -> f(k, args...), ks)
 
 (κ::KernelSum)(x, y) = _sum((k, x, y) -> k(x, y), κ.kernels, x, y)
 

--- a/test/kernels/kernelsum.jl
+++ b/test/kernels/kernelsum.jl
@@ -2,21 +2,24 @@
     k1 = LinearKernel()
     k2 = SqExponentialKernel()
     k = KernelSum(k1, k2)
-    @test k == KernelSum([k1, k2]) == KernelSum((k1, k2))
+    kvec = KernelSum([k1, k2])
+    @test k == kvec == KernelSum((k1, k2))
     for (_k1, _k2) in Iterators.product(
         (k1, KernelSum((k1,)), KernelSum([k1])), (k2, KernelSum((k2,)), KernelSum([k2]))
     )
         @test k == _k1 + _k2
+        @test kvec == _k1 + _k2
     end
-    @test length(k) == 2
-    @test repr(k) == (
+    @test length(k) == length(kvec) == 2
+    @test repr(k) ==
+        repr(kvec) ==
         "Sum of 2 kernels:\n" *
         "\tLinear Kernel (c = 0.0)\n" *
-        "\tSquared Exponential Kernel (metric = Euclidean(0.0))"
-    )
+        "\tSquared Exponential Kernel (metric = Distances.Euclidean(0.0))"
 
     # Standardised tests.
     test_interface(k, Float64)
+    test_interface(kvec, Float64)
     test_interface(ConstantKernel(; c=1.5) + WhiteKernel(), Vector{String})
     test_ADs(x -> KernelSum(SqExponentialKernel(), LinearKernel(; c=exp(x[1]))), rand(1))
     test_interface_ad_perf(2.4, StableRNG(123456)) do c

--- a/test/kernels/kernelsum.jl
+++ b/test/kernels/kernelsum.jl
@@ -15,7 +15,7 @@
         repr(kvec) ==
         "Sum of 2 kernels:\n" *
         "\tLinear Kernel (c = 0.0)\n" *
-        "\tSquared Exponential Kernel (metric = Distances.Euclidean(0.0))"
+        "\tSquared Exponential Kernel (metric = Euclidean(0.0))"
 
     # Standardised tests.
     test_interface(k, Float64)


### PR DESCRIPTION
<!-- Comment lines like this one will remain invisible -->

<!-- Thank you for your contribution! Please fill in this template so that we
can understand your intent and the proposed changes. If anything about this
template is unclear, just mention it! -->

**Summary**
Add the `_sum` interface for vectors, allowing to use `Vector` in `KernelSum`. This is to fix #497 

**Proposed changes**

Add a method for `_sum`  and add the same tests existing for `KerrnelSum{<:Tuple}` to `KernelSum{<:AbstractVector}`.
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
* ...

**What alternatives have you considered?**
:shrug: 

**Breaking changes**
none