### PR TITLE
Fix KernelFunctions on Julia 1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.3'
           - '1'
-          - '1.6'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.63"
+version = "0.10.64"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -153,7 +153,7 @@ function ChainRulesCore.rrule(
         d̄ = ChainRulesCore.Tangent{typeof(d)}(; r=r̄)
         return NoTangent(), d̄, @thunk(project_x(x̄))
     end
-    return Distances.pairwise(d, x; dims), pairwise_pullback
+    return Distances.pairwise(d, x; dims=dims), pairwise_pullback
 end
 
 function ChainRulesCore.rrule(
@@ -190,7 +190,7 @@ function ChainRulesCore.rrule(
         d̄ = ChainRulesCore.Tangent{typeof(d)}(; r=r̄)
         return NoTangent(), d̄, @thunk(project_x(x̄)), @thunk(project_y(ȳ))
     end
-    return Distances.pairwise(d, x, y; dims), pairwise_pullback
+    return Distances.pairwise(d, x, y; dims=dims), pairwise_pullback
 end
 
 function ChainRulesCore.rrule(
@@ -229,7 +229,7 @@ function ChainRulesCore.rrule(::Type{<:ColVecs}, X::AbstractMatrix)
             "or because some external computation has acted on `ColVecs` to produce a vector of vectors." *
             "In the former case, to solve this issue overload `kernelmatrix(_diag)` for your kernel for `ColVecs`." *
             "In the latter case, one needs to track down the `rrule` whose pullback returns a `Vector{Vector{T}}`," *
-            " rather than a `Tangent`, as the cotangent / gradient for `ColVecs` input, and circumvent it."
+            " rather than a `Tangent`, as the cotangent / gradient for `ColVecs` input, and circumvent it.",
         )
     end
     return ColVecs(X), ColVecs_pullback


### PR DESCRIPTION
https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/pull/531 (included in KernelFunctions 0.10.62 and 0.10.63) broke KernelFunctions on Julia 1.3, which broke support and tests in downstream packages such as AbstractGPsMakie. The problem was that in CI the oldest supported Julia version was not tested.

I think it would be fine to drop support for Julia < 1.6 (even though I don't see the need as long as it works and does not impact development significantly) but before changing the Julia compat of KernelFunctions we have to fix support on Julia >= 1.3: Otherwise Pkg will always give people on such older Julia versions a broken KernelFunctions version (that currently can't even be loaded). Alternatively, we could mess with the registry and try to fix compat bounds retroactively but in my experience it's generally considered better practice to register bug fix releases than modifying existing releases (e.g. yanking a release can also break existing Manifest.toml files). 