### PR TITLE
Preserve Float type for Periodic Kernel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KernelFunctions"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.10.63"
+version = "0.10.64"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/basekernels/periodic.jl
+++ b/src/basekernels/periodic.jl
@@ -34,7 +34,7 @@ PeriodicKernel(T::DataType, dims::Int=1) = PeriodicKernel(; r=ones(T, dims))
 
 metric(κ::PeriodicKernel) = Sinus(κ.r)
 
-kappa(::PeriodicKernel, d::Real) = exp(-0.5d)
+kappa(::PeriodicKernel, d::Real) = exp(-d / 2)
 
 function Base.show(io::IO, κ::PeriodicKernel)
     return print(io, "Periodic Kernel, length(r) = $(length(κ.r))")

--- a/test/basekernels/periodic.jl
+++ b/test/basekernels/periodic.jl
@@ -8,7 +8,7 @@
     @test k(v1, v2) ≈ exp(-0.5 * sum(abs2, sinpi.(v1 - v2) ./ r))
     @test k(v1, v2) == k(v2, v1)
     @test PeriodicKernel(3)(v1, v2) == PeriodicKernel(; r=ones(3))(v1, v2)
-    @test isa(PeriodicKernel(r=Float32.(r))(Float32.(v1), Float32.(v2)), Float32)
+    @test PeriodicKernel(; r=Float32.(r))(Float32.(v1), Float32.(v2)) isa Float32
     @test repr(k) == "Periodic Kernel, length(r) = $(length(r))"
 
     # Standardised tests.

--- a/test/basekernels/periodic.jl
+++ b/test/basekernels/periodic.jl
@@ -8,6 +8,7 @@
     @test k(v1, v2) ≈ exp(-0.5 * sum(abs2, sinpi.(v1 - v2) ./ r))
     @test k(v1, v2) == k(v2, v1)
     @test PeriodicKernel(3)(v1, v2) == PeriodicKernel(; r=ones(3))(v1, v2)
+    @test isa(PeriodicKernel(r=Float32.(r))(Float32.(v1), Float32.(v2)), Float32) 
     @test repr(k) == "Periodic Kernel, length(r) = $(length(r))"
 
     # Standardised tests.

--- a/test/basekernels/periodic.jl
+++ b/test/basekernels/periodic.jl
@@ -8,7 +8,7 @@
     @test k(v1, v2) ≈ exp(-0.5 * sum(abs2, sinpi.(v1 - v2) ./ r))
     @test k(v1, v2) == k(v2, v1)
     @test PeriodicKernel(3)(v1, v2) == PeriodicKernel(; r=ones(3))(v1, v2)
-    @test isa(PeriodicKernel(r=Float32.(r))(Float32.(v1), Float32.(v2)), Float32) 
+    @test isa(PeriodicKernel(r=Float32.(r))(Float32.(v1), Float32.(v2)), Float32)
     @test repr(k) == "Periodic Kernel, length(r) = $(length(r))"
 
     # Standardised tests.


### PR DESCRIPTION
**Summary**
Tiny change to preserve float type of inputs and parameters. For most of the kernels, if the inputs and parameters have Float32 type, then the output has also Float32:
```julia
julia> v1 = 0.9f0; v2 = 0.7f0;
julia> SqExponentialKernel()(v1, v2)
0.9801987f0
julia> GammaRationalKernel(alpha=2.0f0, gamma=1.0f0)(v1, v2)
0.82644624f0
```
However, currently, `PeriodicKernel` doesn't support this:
```julia
julia> PeriodicKernel(r=[1.0f0])(v1, v2)
0.8413515018155655
```
The simple change of `exp(-0.5d)` to `exp(-d / 2)` in its `kappa` function fixes it:
```julia
julia> PeriodicKernel(r=[1.0f0])(v1, v2)
0.8413515f0
```