### PR TITLE
Update check_zygote_type_stability()...

### DIFF
--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -104,7 +104,7 @@ function check_zygote_type_stability(f, args...; ctx=Zygote.Context())
     @inferred f(args...)
     @inferred Zygote._pullback(ctx, f, args...)
     out, pb = Zygote._pullback(ctx, f, args...)
-    @inferred pb(out)
+    @inferred collect(pb(out))
 end
 
 function test_ADs(


### PR DESCRIPTION
so that CI passes with Julia v1.10. Tested locally with Julia v1.10 & v1.11. Forces the expected type to be `Vector{Union{Nothing, @NamedTuple{X::Matrix{Float64}}}}` which is more robust for different package versions. There may be better solutions, but this seems to work.
